### PR TITLE
Destroy & terminate web worker

### DIFF
--- a/src/utils/opus-worker.js
+++ b/src/utils/opus-worker.js
@@ -36,6 +36,10 @@ export default class OpusWorker extends Event {
         this.dispatch('data', data.buffer);
     }
     destroy() {
+        this.worker.postMessage({
+            type: 'destroy'
+        });
+        this.worker.terminate();
         this.worker = null;
         this.offAll();
     }


### PR DESCRIPTION
If I had to guess, this 'destroy' message won't actually make it to the worker before `terminate()` is called, but I don't think there's really a great way to do that other than an artificial delay, which doesn't seem like an amazing choice?