### PR TITLE
Add special handling for corrupted stream opus worker error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ typings/
 
 
 # End of https://www.gitignore.io/api/node
+.idea

--- a/src/opus-to-pcm.js
+++ b/src/opus-to-pcm.js
@@ -1,4 +1,3 @@
-import { appendByteArray } from './utils/utils.js';
 import Event from './utils/event.js';
 import Ogg from './utils/ogg.js';
 import OpusWorker from './utils/opus-worker.js';
@@ -15,7 +14,7 @@ export class OpusToPCM extends Event {
         options = Object.assign({}, defaults, options);
 
         if (nativeSupport) {
-            this.decoder = new Ogg(options.channels); 
+            this.decoder = new Ogg(options.channels);
         } else if(options.fallback) {
             this.decoder = new OpusWorker(options.channels, options);
         } else {
@@ -24,8 +23,11 @@ export class OpusToPCM extends Event {
 
         if (this.decoder) {
             this.decoder.on('data', (data) => {
-              this.dispatch('decode', data);
-              this.ondata(data);
+                this.dispatch('decode', data);
+                this.ondata(data);
+            });
+            this.decoder.on('corrupted_stream', (data) => {
+                this.dispatch('corrupted_stream', data);
             });
         }
     }
@@ -38,7 +40,7 @@ export class OpusToPCM extends Event {
 
     decode(packet) {
         if (!this.decoder) {
-            throw ('opps! no decoder is found to decode');
+            throw ('oops! no decoder is found to decode');
         }
         this.decoder.decode(packet);
     }

--- a/src/opus-to-pcm.js
+++ b/src/opus-to-pcm.js
@@ -9,7 +9,8 @@ export class OpusToPCM extends Event {
         let nativeSupport = false;
         let defaults = {
             channels: 1,
-            fallback: true
+            fallback: true,
+            handleCorruptedStream: false
         };
         options = Object.assign({}, defaults, options);
 

--- a/src/utils/opus-worker.js
+++ b/src/utils/opus-worker.js
@@ -1,19 +1,29 @@
 import Event from './event.js';
-import OpusWorkerBin from './opus.min.worker'
+import OpusWorkerBin from './opus.min.worker';
 
 export default class OpusWorker extends Event {
     constructor(channels, config) {
         super('worker');
         this.worker = new OpusWorkerBin();
         this.worker.addEventListener('message', this.onMessage.bind(this));
+        this.worker.addEventListener('error', (event) => {
+            if (!event.message || !event.message.includes('corrupted stream')) {
+                return;
+            }
+            const handled = this.dispatch('corrupted_stream');
+            if (!handled) {
+                return;
+            }
+            event.preventDefault();
+        });
         this.config = Object.assign({
-          rate: 24000,
-          channels:channels
+            rate: 24000,
+            channels
         }, config, {rate: config.sampleRate});
 
         let message = {
-          type: 'init',
-          config: this.config
+            type: 'init',
+            config: this.config
         };
         this.sampleRate = this.config.rate;
         this.worker.postMessage(JSON.parse(JSON.stringify(message)));

--- a/src/utils/opus-worker.js
+++ b/src/utils/opus-worker.js
@@ -7,13 +7,10 @@ export default class OpusWorker extends Event {
         this.worker = new OpusWorkerBin();
         this.worker.addEventListener('message', this.onMessage.bind(this));
         this.worker.addEventListener('error', (event) => {
-            if (!event.message || !event.message.includes('corrupted stream')) {
+            if (!event.message || !event.message.includes('corrupted stream') || !this.config.handleCorruptedStream) {
                 return;
             }
-            const handled = this.dispatch('corrupted_stream');
-            if (!handled) {
-                return;
-            }
+            this.dispatch('corrupted_stream');
             event.preventDefault();
         });
         this.config = Object.assign({


### PR DESCRIPTION
The code is ugly, but the general idea here is that I'm attempting to pass back to the caller when a special error "corrupted stream" occurs