### PR TITLE
Fixed first decoded null packet

### DIFF
--- a/src/utils/opus-worker.js
+++ b/src/utils/opus-worker.js
@@ -40,6 +40,16 @@ export default class OpusWorker extends Event {
 
     onMessage(event) {
         let data = event.data;
+        // The first message from OpusWorkerBin does not contain a buffer in event.data
+        // Instead, it contains the following object:
+        // data: {
+        //   method: "ready",
+        //   type: "RPC"
+        // }
+        if (data.type === 'RPC') {
+            console.error('Not a data message');
+            return;
+        }
         this.dispatch('data', data.buffer);
     }
 

--- a/src/utils/opus-worker.js
+++ b/src/utils/opus-worker.js
@@ -47,7 +47,6 @@ export default class OpusWorker extends Event {
         //   type: "RPC"
         // }
         if (data.type === 'RPC') {
-            console.error('Not a data message');
             return;
         }
         this.dispatch('data', data.buffer);


### PR DESCRIPTION
Fix for an issue found by @adambailey:

> on the new version with this patch, the very first packet from the decoder is undefined (edited) 
> I’m receiving decode event before i have event fed the decoder a single packet


It looks like previously this bug was hidden because of different timing during decoder initialization.