### PR TITLE
Performance/memory improvements

### DIFF
--- a/src/utils/event.js
+++ b/src/utils/event.js
@@ -1,7 +1,7 @@
 export default class Event {
     constructor(type) {
         this.listener = {};
-        this.type = type | '';
+        this.type = type || '';
     }
 
     on(event, fn) {
@@ -29,7 +29,7 @@ export default class Event {
 
     dispatch(event, data) {
         if (this.listener[event]) {
-            this.listener[event].map((each) => {
+            this.listener[event].forEach((each) => {
                 each.apply(null, [data]);
             });
             return true;

--- a/src/utils/opus-worker.js
+++ b/src/utils/opus-worker.js
@@ -23,7 +23,7 @@ export default class OpusWorker extends Event {
             config: this.config
         };
         this.sampleRate = this.config.rate;
-        this.worker.postMessage(JSON.parse(JSON.stringify(message)));
+        this.worker.postMessage(message);
     }
 
     getSampleRate() {
@@ -35,7 +35,7 @@ export default class OpusWorker extends Event {
             type: 'decode',
             buffer: packet
         };
-        this.worker.postMessage(workerData);
+        this.worker.postMessage(workerData, [packet.buffer]);
     }
 
     onMessage(event) {

--- a/src/utils/opus-worker.js
+++ b/src/utils/opus-worker.js
@@ -30,6 +30,8 @@ export default class OpusWorker extends Event {
         return this.sampleRate;
     }
 
+    // NOTE: This function transfers the memory ownership of the packet
+    // to a web worker.
     decode(packet) {
         let workerData = {
             type: 'decode',

--- a/src/utils/opus-worker.js
+++ b/src/utils/opus-worker.js
@@ -35,6 +35,8 @@ export default class OpusWorker extends Event {
             type: 'decode',
             buffer: packet
         };
+        // Passing the buffer with the transfer list prevents the browser
+        // from copying the bytes. Same physical memory, but now owned by the worker thread
         this.worker.postMessage(workerData, [packet.buffer]);
     }
 


### PR DESCRIPTION
## Summary

Performance and correctness fixes for the opus-to-pcm decoder library.

- Use Transferable Objects when posting Opus packets to the decoder Web Worker, eliminating a full ArrayBuffer copy on every packet
- Replace `.map()` with `.forEach()` in the event dispatcher to avoid allocating a throwaway array on every event dispatch
- Remove redundant `JSON.parse(JSON.stringify())` wrapper around the worker init message -- `postMessage` already performs structured cloning
- Fix bitwise OR (`|`) to logical OR (`||`) in the Event constructor -- was silently coercing the type string to `0` (field is unused, so no behavioral change)

## Details

The main change is the Transferable Objects fix. Previously, every Opus audio packet sent to the worker was copied via structured cloning. By passing the ArrayBuffer in the `postMessage` transfer list, ownership of the memory is moved to the worker at zero cost instead of being copied. The tradeoff is the caller's buffer is neutered after the call, which is fine since nothing reads from the packet after passing it to `decode()`.