### PR TITLE
fix: manage Blob URL lifecycle manually for the opus worker

### DIFF
--- a/src/utils/opus-worker.js
+++ b/src/utils/opus-worker.js
@@ -1,10 +1,50 @@
 import Event from './event.js';
-import OpusWorkerBin from './opus.min.worker';
+// Imported via webpack `asset/source` (or an equivalent raw-string import in
+// other bundlers). This gives us the minified worker bundle as a plain JS
+// string, so we can manage the Blob URL lifecycle ourselves rather than
+// relying on a bundler loader to do it for us.
+//
+// We used to import this file with the webpack worker-loader convention
+// (`import OpusWorkerBin from './opus.min.worker'; new OpusWorkerBin()`),
+// which under `workerize-loader@2.0.2` with `inline: true` expanded to a
+// generated wrapper that interpolated the build-time `URL.createObjectURL(
+// new Blob([src]))` expression twice — once into `new Worker(...)` and once
+// into `URL.revokeObjectURL(...)` — so every constructed decoder allocated
+// two Blobs, handed the first URL to the Worker, and then revoked a fresh
+// second URL that nothing else referenced. That leaked ~918 KB of retained
+// Blob storage per decoder in the renderer.
+import opusWorkerSource from './opus.min.worker.js';
+
+// Cache a single Blob across all OpusWorker instances. The underlying string
+// is already held once in the bundle as a module constant; caching the Blob
+// lets us allocate exactly one Blob per process instead of one per decoder.
+let cachedWorkerBlob = null;
+
+function getWorkerBlob() {
+    if (!cachedWorkerBlob) {
+        cachedWorkerBlob = new Blob([opusWorkerSource], {type: 'application/javascript'});
+    }
+    return cachedWorkerBlob;
+}
+
+// Create a Worker from the inlined opus decoder bundle and revoke the backing
+// blob: URL synchronously after construction. The Worker latches the
+// resource during `new Worker(url)`, so revoking immediately afterwards is
+// both safe and what MDN recommends:
+//   https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL#memory_management
+function createOpusWorker() {
+    const url = URL.createObjectURL(getWorkerBlob());
+    try {
+        return new Worker(url, {name: 'opus.min.worker.js'});
+    } finally {
+        URL.revokeObjectURL(url);
+    }
+}
 
 export default class OpusWorker extends Event {
     constructor(channels, config) {
         super('worker');
-        this.worker = new OpusWorkerBin();
+        this.worker = createOpusWorker();
         this.worker.addEventListener('message', this.onMessage.bind(this));
         this.worker.addEventListener('error', (event) => {
             if (!event.message || !event.message.includes('corrupted stream') || !this.config.handleCorruptedStream) {
@@ -44,7 +84,7 @@ export default class OpusWorker extends Event {
 
     onMessage(event) {
         let data = event.data;
-        // The first message from OpusWorkerBin does not contain a buffer in event.data
+        // The first message from the opus worker does not contain a buffer in event.data
         // Instead, it contains the following object:
         // data: {
         //   method: "ready",


### PR DESCRIPTION
## Summary
- Rewrite `opus-worker.js` to import `opus.min.worker.js` as a raw string and drive the Blob URL lifecycle ourselves: cache a single Blob, `URL.createObjectURL` -> `new Worker(url)` -> `URL.revokeObjectURL(url)` in a `try/finally`.
- Removes the dependency on the downstream bundler's worker loader to produce correct create/revoke pairing. Under `workerize-loader@2.0.2 { inline: true }` (used by the Zello Channels JS SDK build) the generated wrapper interpolated the build-time `URL.createObjectURL(new Blob([src]))` expression twice, handing the first URL to the Worker and revoking a fresh second Blob's URL, leaking one ~918 KB Blob per constructed `OpusWorker`.
- Pairs with the Zello Channels JS SDK change that swaps `workerize-loader` for `type: 'asset/source'` so this file's `import opusWorkerSource from './opus.min.worker.js'` is loaded as a raw string. Mirrors the existing `encoder.js` pattern for `opus-recorder`.

## Test plan
- Rebuilt the Zello Channels JS SDK against this submodule change and confirmed `zcc.decoder.js` now has `createObjectURL=1 revokeObjectURL=1` (was `2`/`1`) with the emitted wrapper `try { return new Worker(f, {name:'opus.min.worker.js'}) } finally { URL.revokeObjectURL(f) }`.
- End-to-end validation in `zello-desktop` tracked in DESKTOP-535: `blobUrlLive` and `blobUrlLeakedBytes` stay near zero across 33 decoder constructions over 315s.


[DESKTOP-535]: https://zelloptt.atlassian.net/browse/DESKTOP-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ