### PR TITLE
feat(decoder): opt-in WebCodecs-based native Opus decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Available options are:
 
 *fallback* - true/false. Whether it will use libopus as fallback or not. Default is true.
 
+*useNative* - true/false. Opt in to a native decoder path backed by the browser's [WebCodecs `AudioDecoder`](https://developer.mozilla.org/en-US/docs/Web/API/AudioDecoder) instead of the libopus-in-worker bundle. Default is false. When `useNative: true` is set on an environment that doesn't provide `AudioDecoder`, the decoder falls back to libopus iff `fallback: true`. Recommended for Chromium-based environments (e.g. Electron apps such as Dispatch Hub) where `AudioDecoder` + `codec: 'opus'` is guaranteed by spec and avoids the ~900KB inlined worker bundle entirely.
+
 Decoder fire an event *decode* whenever it completes decoding. Usually it decodes several opus packet at a time for better performance although it need to be provided single opus packet into *decode* method.
 
 **Complete example:**

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Available options are:
 
 *fallback* - true/false. Whether it will use libopus as fallback or not. Default is true.
 
-*useNative* - true/false. Opt in to a native decoder path backed by the browser's [WebCodecs `AudioDecoder`](https://developer.mozilla.org/en-US/docs/Web/API/AudioDecoder) instead of the libopus-in-worker bundle. Default is false. When `useNative: true` is set on an environment that doesn't provide `AudioDecoder`, the decoder falls back to libopus iff `fallback: true`. Recommended for Chromium-based environments (e.g. Electron apps such as Dispatch Hub) where `AudioDecoder` + `codec: 'opus'` is guaranteed by spec and avoids the ~900KB inlined worker bundle entirely.
+*useNative* - true/false. Opt in to a native decoder path backed by the browser's [WebCodecs `AudioDecoder`](https://developer.mozilla.org/en-US/docs/Web/API/AudioDecoder) instead of the libopus-in-worker bundle. Default is false. When `useNative: true` is set on an environment that doesn't provide `AudioDecoder`, the decoder falls back to libopus iff `fallback: true`. Recommended for Chromium-based environments where `AudioDecoder` + `codec: 'opus'` is guaranteed by spec and avoids the ~900KB inlined worker bundle entirely.
 
 Decoder fire an event *decode* whenever it completes decoding. Usually it decodes several opus packet at a time for better performance although it need to be provided single opus packet into *decode* method.
 

--- a/src/opus-to-pcm.js
+++ b/src/opus-to-pcm.js
@@ -13,20 +13,6 @@ export class OpusToPCM extends Event {
         };
         options = Object.assign({}, defaults, options);
 
-        // Opt-in native Opus decoding via the browser's WebCodecs
-        // `AudioDecoder`. Disabled by default; existing consumers that
-        // don't pass `useNative` keep the `OpusWorker` (libopus-in-worker)
-        // path they've always used.
-        //
-        // When `useNative: true` is requested but the environment can't
-        // provide the WebCodecs globals, fall through to the worker path
-        // iff `fallback: true` (the default). Chromium-based environments
-        // (Electron / Dispatch Hub) ship `AudioDecoder` and are required
-        // by spec to support `codec: 'opus'`. We also gate on
-        // `EncodedAudioChunk` because `WebCodecsOpus.decode()` constructs
-        // one per packet; an environment with `AudioDecoder` but no
-        // `EncodedAudioChunk` (e.g. behind a partial flag) would error
-        // on every packet otherwise.
         let nativeSupport = options.useNative &&
             typeof AudioDecoder !== 'undefined' &&
             typeof EncodedAudioChunk !== 'undefined';

--- a/src/opus-to-pcm.js
+++ b/src/opus-to-pcm.js
@@ -13,7 +13,7 @@ export class OpusToPCM extends Event {
         };
         options = Object.assign({}, defaults, options);
 
-        let nativeSupport = options.useNative &&
+        const nativeSupport = options.useNative &&
             typeof AudioDecoder !== 'undefined' &&
             typeof EncodedAudioChunk !== 'undefined';
 

--- a/src/opus-to-pcm.js
+++ b/src/opus-to-pcm.js
@@ -1,22 +1,33 @@
 import Event from './utils/event.js';
-import Ogg from './utils/ogg.js';
 import OpusWorker from './utils/opus-worker.js';
+import WebCodecsOpus from './utils/webcodecs-opus.js';
 export class OpusToPCM extends Event {
 
     constructor(options) {
         super('decoder');
-        window.MediaSource = window.MediaSource || window.WebKitMediaSource;
-        let nativeSupport = false;
         let defaults = {
             channels: 1,
             fallback: true,
+            useNative: false,
             handleCorruptedStream: false
         };
         options = Object.assign({}, defaults, options);
 
+        // Opt-in native Opus decoding via the browser's WebCodecs
+        // `AudioDecoder`. Disabled by default; existing consumers that
+        // don't pass `useNative` keep the `OpusWorker` (libopus-in-worker)
+        // path they've always used.
+        //
+        // When `useNative: true` is requested but the environment can't
+        // provide `AudioDecoder`, fall through to the worker path iff
+        // `fallback: true` (the default). Chromium-based environments
+        // (Electron / Dispatch Hub) ship `AudioDecoder` and are required
+        // by spec to support `codec: 'opus'`.
+        let nativeSupport = options.useNative && typeof AudioDecoder !== 'undefined';
+
         if (nativeSupport) {
-            this.decoder = new Ogg(options.channels);
-        } else if(options.fallback) {
+            this.decoder = new WebCodecsOpus(options.channels, options);
+        } else if (options.fallback) {
             this.decoder = new OpusWorker(options.channels, options);
         } else {
             this.decoder = null;

--- a/src/opus-to-pcm.js
+++ b/src/opus-to-pcm.js
@@ -19,18 +19,35 @@ export class OpusToPCM extends Event {
         // path they've always used.
         //
         // When `useNative: true` is requested but the environment can't
-        // provide `AudioDecoder`, fall through to the worker path iff
-        // `fallback: true` (the default). Chromium-based environments
+        // provide the WebCodecs globals, fall through to the worker path
+        // iff `fallback: true` (the default). Chromium-based environments
         // (Electron / Dispatch Hub) ship `AudioDecoder` and are required
-        // by spec to support `codec: 'opus'`.
-        let nativeSupport = options.useNative && typeof AudioDecoder !== 'undefined';
+        // by spec to support `codec: 'opus'`. We also gate on
+        // `EncodedAudioChunk` because `WebCodecsOpus.decode()` constructs
+        // one per packet; an environment with `AudioDecoder` but no
+        // `EncodedAudioChunk` (e.g. behind a partial flag) would error
+        // on every packet otherwise.
+        let nativeSupport = options.useNative &&
+            typeof AudioDecoder !== 'undefined' &&
+            typeof EncodedAudioChunk !== 'undefined';
 
+        this.decoder = null;
         if (nativeSupport) {
-            this.decoder = new WebCodecsOpus(options.channels, options);
-        } else if (options.fallback) {
+            const native = new WebCodecsOpus(options.channels, options);
+            if (native.isSupported) {
+                this.decoder = native;
+            } else {
+                // WebCodecs claimed support at the global level but
+                // `AudioDecoder.configure()` rejected our config (e.g.
+                // a build that exposes the API but ships no opus
+                // decoder). Tear the dead instance down and fall
+                // through to the worker path under the same `fallback`
+                // policy as the no-native-at-all case.
+                native.destroy();
+            }
+        }
+        if (!this.decoder && options.fallback) {
             this.decoder = new OpusWorker(options.channels, options);
-        } else {
-            this.decoder = null;
         }
 
         if (this.decoder) {

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -15,9 +15,8 @@ import Event from './event.js';
 //
 // It is enabled via `new OpusToPCM({ useNative: true })` and only when
 // `typeof AudioDecoder !== 'undefined'`. Opus is a required codec in the
-// WebCodecs spec, so in any Chromium-based environment (notably Electron,
-// which is where Dispatch Hub lives) `AudioDecoder` + `codec: 'opus'` is
-// guaranteed to be supported. For non-Chromium environments where
+// WebCodecs spec, so any user agent that exposes `AudioDecoder` is
+// required to support `codec: 'opus'`. In environments where
 // `AudioDecoder` is missing, `OpusToPCM` falls back to `OpusWorker` when
 // `fallback: true`.
 //

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -66,7 +66,10 @@ const MAX_REBUILD_ATTEMPTS = 5;
 // case where the audio process hangs or the promise never settles.
 // Without it, a stuck flush would retain this instance (and its event
 // listeners) for the lifetime of the page.
-const FLUSH_TIMEOUT_MS = 1000;
+//
+// Exported so the test suite can assert against the same value rather
+// than hardcoding it; not part of the public runtime API.
+export const FLUSH_TIMEOUT_MS = 1000;
 
 export default class WebCodecsOpus extends Event {
     constructor(channels, config) {
@@ -121,7 +124,7 @@ export default class WebCodecsOpus extends Event {
             if (old.state !== 'closed') {
                 old.close();
             }
-        } catch {
+        } catch (_) {
             // Decoder is already in an unrecoverable state; nothing to do.
         }
     }
@@ -141,7 +144,7 @@ export default class WebCodecsOpus extends Event {
     safeDispatch(event, data) {
         try {
             this.dispatch(event, data);
-        } catch {
+        } catch (_) {
             // Listener bug; not a decoder problem. Intentionally
             // swallowed so we don't tear down a healthy decoder over
             // a defect downstream.
@@ -302,7 +305,7 @@ export default class WebCodecsOpus extends Event {
                 if (dec.state !== 'closed') {
                     dec.close();
                 }
-            } catch {
+            } catch (_) {
                 // Decoder is already in an unrecoverable state; nothing to do.
             }
             this.offAll();
@@ -310,7 +313,7 @@ export default class WebCodecsOpus extends Event {
         let flushed;
         try {
             flushed = dec.flush();
-        } catch {
+        } catch (_) {
             // flush() rejects/throws if the decoder is already errored;
             // skip straight to teardown.
             finalize();
@@ -325,7 +328,12 @@ export default class WebCodecsOpus extends Event {
     }
 }
 
-function toUint8Array(packet) {
+// The helpers below are module-private in the runtime path but exported
+// (named) so the unit tests can exercise them directly. They are pure
+// functions over plain typed-arrays, with no dependency on WebCodecs,
+// the `Event` class, or browser globals.
+
+export function toUint8Array(packet) {
     if (!packet) {
         return null;
     }
@@ -341,7 +349,7 @@ function toUint8Array(packet) {
     return null;
 }
 
-function interleave(planes, numFrames, numChannels) {
+export function interleave(planes, numFrames, numChannels) {
     if (numChannels === 1) {
         return planes[0];
     }
@@ -363,7 +371,7 @@ function interleave(planes, numFrames, numChannels) {
 // brickwall, but it's adequate for voice at any of the Opus-supported
 // output rates (48k, 24k, 16k, 12k, 8k) and much better than naive
 // subsampling for wideband content squeezed into narrowband targets.
-function decimateInterleave(planes, numFrames, numChannels, decim) {
+export function decimateInterleave(planes, numFrames, numChannels, decim) {
     if (decim === 1) {
         return interleave(planes, numFrames, numChannels);
     }
@@ -387,7 +395,7 @@ function decimateInterleave(planes, numFrames, numChannels, decim) {
 // Fallback resampler for non-integer ratios. Linear interpolation is fine
 // for speech bandwidths; anyone shipping music through this path should
 // bring their own resampler.
-function linearResampleInterleave(planes, numFrames, numChannels, srcRate, dstRate) {
+export function linearResampleInterleave(planes, numFrames, numChannels, srcRate, dstRate) {
     const outFrames = Math.floor(numFrames * dstRate / srcRate);
     const out = new Float32Array(outFrames * numChannels);
     const ratio = srcRate / dstRate;

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -21,6 +21,27 @@ import Event from './event.js';
 // `AudioDecoder` is missing, `OpusToPCM` falls back to `OpusWorker` when
 // `fallback: true`.
 //
+// ## Sample-rate handling
+//
+// WebCodecs' Opus decoder in Chromium only accepts `sampleRate: 48000`
+// in `AudioDecoderConfig` and always emits 48 kHz `AudioData`, even
+// though libopus itself supports returning decoded audio at 8, 12, 16,
+// 24 or 48 kHz via `opus_decoder_create(Fs, ...)`. The Zello Channels
+// SDK, however, derives the downstream player's sample rate from the
+// codec header attached to each stream and passes it in as
+// `options.sampleRate` (24 kHz for narrow-/mediumband streams, 48 kHz
+// for wideband). If we just forwarded the raw 48 kHz samples the
+// `OpusWorker` replacement would play back at half speed / an octave
+// low whenever the session picked 24 kHz.
+//
+// To preserve drop-in behavior, we resample the WebCodecs output down
+// to `options.sampleRate` before emitting it and report that same rate
+// from `getSampleRate()`. For the 48 kHz case the resample is a no-op;
+// for 24 kHz (the common case) it's an exact 2:1 decimation. For any
+// other requested rate we fall back to linear interpolation, which is
+// more than adequate for 16-bit-equivalent voice content that has
+// already been band-limited by the encoder.
+//
 // Interface contract (matches `OpusWorker`/`Ogg`):
 //   - emits 'data'              with an interleaved Float32Array of PCM
 //   - emits 'corrupted_stream'  when a decode error is surfaced (only when
@@ -29,24 +50,21 @@ import Event from './event.js';
 //   - `decode(packet)`          accepts a Uint8Array/ArrayBuffer of one
 //                               Opus packet
 //   - `destroy()`               tears down the decoder
-//
-// Opus always decodes at 48 kHz. The decoder requests interleaved f32
-// output from `AudioData.copyTo` when the platform supports it and falls
-// back to copying per-plane and interleaving in JS otherwise.
 
-const OPUS_SAMPLE_RATE = 48000;
+const WEBCODECS_OPUS_RATE = 48000;
 
 export default class WebCodecsOpus extends Event {
     constructor(channels, config) {
         super('webcodecs-opus');
         this.channels = channels || 1;
         this.config = config || {};
-        this.sampleRate = OPUS_SAMPLE_RATE;
-        // Monotonically-increasing timestamp in microseconds. WebCodecs only
-        // requires input timestamps to be strictly increasing for ordering;
-        // the value itself is not inspected by us on the output side. A
-        // per-packet 60ms step is the maximum Opus frame duration and leaves
-        // headroom for any downstream consumer that does care.
+        // Target output rate. Matches the rate the Zello Channels SDK's
+        // player was configured with for this stream.
+        this.outputSampleRate = this.config.sampleRate || WEBCODECS_OPUS_RATE;
+        // Monotonically-increasing timestamp in microseconds. WebCodecs
+        // only requires input timestamps to be strictly increasing for
+        // ordering; the value is not inspected by us on the output side.
+        // A per-packet 60ms step is the upper bound on an Opus frame.
         this.nextTimestamp = 0;
         this.closed = false;
 
@@ -58,7 +76,7 @@ export default class WebCodecsOpus extends Event {
         try {
             this.decoder.configure({
                 codec: 'opus',
-                sampleRate: this.sampleRate,
+                sampleRate: WEBCODECS_OPUS_RATE,
                 numberOfChannels: this.channels
             });
         } catch (err) {
@@ -67,7 +85,7 @@ export default class WebCodecsOpus extends Event {
     }
 
     getSampleRate() {
-        return this.sampleRate;
+        return this.outputSampleRate;
     }
 
     decode(packet) {
@@ -90,7 +108,7 @@ export default class WebCodecsOpus extends Event {
             this._onError(err);
             return;
         }
-        this.nextTimestamp += 60000; // 60ms in us; upper bound on an Opus frame
+        this.nextTimestamp += 60000; // 60ms in us, upper bound on an Opus frame
 
         try {
             this.decoder.decode(chunk);
@@ -107,34 +125,26 @@ export default class WebCodecsOpus extends Event {
                 return;
             }
 
-            const interleaved = new Float32Array(numFrames * numChannels);
-
-            // Fast path: ask the UA for interleaved f32 directly.
-            let gotInterleaved = false;
-            if (numChannels === 1) {
-                try {
-                    audioData.copyTo(interleaved, {planeIndex: 0, format: 'f32'});
-                    gotInterleaved = true;
-                } catch (_) {
-                    // Fall through to planar copy.
-                }
-            } else {
-                try {
-                    audioData.copyTo(interleaved, {planeIndex: 0, format: 'f32'});
-                    gotInterleaved = true;
-                } catch (_) {
-                    // Not all implementations expose 'f32'; fall back to planar.
-                }
+            // Always pull planar f32 from WebCodecs: it's the one format
+            // the spec requires implementations to support, and it makes
+            // the subsequent resample step channel-agnostic.
+            const planes = new Array(numChannels);
+            for (let ch = 0; ch < numChannels; ch++) {
+                planes[ch] = new Float32Array(numFrames);
+                audioData.copyTo(planes[ch], {planeIndex: ch, format: 'f32-planar'});
             }
 
-            if (!gotInterleaved) {
-                for (let ch = 0; ch < numChannels; ch++) {
-                    const plane = new Float32Array(numFrames);
-                    audioData.copyTo(plane, {planeIndex: ch, format: 'f32-planar'});
-                    for (let i = 0; i < numFrames; i++) {
-                        interleaved[i * numChannels + ch] = plane[i];
-                    }
-                }
+            const srcRate = audioData.sampleRate || WEBCODECS_OPUS_RATE;
+            const dstRate = this.outputSampleRate;
+
+            let interleaved;
+            if (srcRate === dstRate) {
+                interleaved = interleave(planes, numFrames, numChannels);
+            } else if (srcRate % dstRate === 0) {
+                const decim = srcRate / dstRate;
+                interleaved = decimateInterleave(planes, numFrames, numChannels, decim);
+            } else {
+                interleaved = linearResampleInterleave(planes, numFrames, numChannels, srcRate, dstRate);
             }
 
             this.dispatch('data', interleaved);
@@ -179,4 +189,54 @@ function toUint8Array(packet) {
         return new Uint8Array(packet.buffer, packet.byteOffset, packet.byteLength);
     }
     return null;
+}
+
+function interleave(planes, numFrames, numChannels) {
+    if (numChannels === 1) {
+        return planes[0];
+    }
+    const out = new Float32Array(numFrames * numChannels);
+    for (let i = 0; i < numFrames; i++) {
+        for (let ch = 0; ch < numChannels; ch++) {
+            out[i * numChannels + ch] = planes[ch][i];
+        }
+    }
+    return out;
+}
+
+// Integer-factor decimation. Opus output for voice is already effectively
+// band-limited by the encoder to well under the target Nyquist (e.g.
+// narrowband voice at 4 kHz into a 24 kHz stream has ~20 kHz of headroom),
+// so plain decimation is adequate without an additional anti-alias filter.
+function decimateInterleave(planes, numFrames, numChannels, decim) {
+    const outFrames = Math.floor(numFrames / decim);
+    const out = new Float32Array(outFrames * numChannels);
+    for (let i = 0; i < outFrames; i++) {
+        const srcIdx = i * decim;
+        for (let ch = 0; ch < numChannels; ch++) {
+            out[i * numChannels + ch] = planes[ch][srcIdx];
+        }
+    }
+    return out;
+}
+
+// Fallback resampler for non-integer ratios. Linear interpolation is fine
+// for speech bandwidths; anyone shipping music through this path should
+// bring their own resampler.
+function linearResampleInterleave(planes, numFrames, numChannels, srcRate, dstRate) {
+    const outFrames = Math.floor(numFrames * dstRate / srcRate);
+    const out = new Float32Array(outFrames * numChannels);
+    const ratio = srcRate / dstRate;
+    for (let i = 0; i < outFrames; i++) {
+        const srcPos = i * ratio;
+        const i0 = Math.floor(srcPos);
+        const i1 = Math.min(i0 + 1, numFrames - 1);
+        const frac = srcPos - i0;
+        for (let ch = 0; ch < numChannels; ch++) {
+            const a = planes[ch][i0];
+            const b = planes[ch][i1];
+            out[i * numChannels + ch] = a + (b - a) * frac;
+        }
+    }
+    return out;
 }

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -51,6 +51,11 @@ import Event from './event.js';
 
 const WEBCODECS_OPUS_RATE = 48000;
 
+// Default channel count when the caller doesn't pass one. Mono is the
+// only mode `OpusToPCM` actually exercises today, but the constructor
+// argument is kept for parity with `OpusWorker(channels, config)`.
+const DEFAULT_CHANNELS = 1;
+
 // Maximum number of times we'll rebuild the underlying `AudioDecoder`
 // in response to errors before giving up on the stream. `AudioDecoder`
 // transitions to 'closed' on any decode error, so to match libopus's
@@ -69,10 +74,30 @@ const MAX_REBUILD_ATTEMPTS = 5;
 // than hardcoding it; not part of the public runtime API.
 export const FLUSH_TIMEOUT_MS = 1000;
 
+// Idempotent close for an `AudioDecoder` that may already be closed
+// or in an error state. `AudioDecoder.close()` throws if the decoder
+// has already transitioned out of a closeable state, so every site
+// that releases a decoder ends up needing the same state-check + try
+// /catch dance. Centralizing it keeps us from silently regressing the
+// "release the underlying media-process resource explicitly" rule one
+// of these sites at a time.
+function safeCloseDecoder(decoder) {
+    if (!decoder) {
+        return;
+    }
+    try {
+        if (decoder.state !== 'closed') {
+            decoder.close();
+        }
+    } catch (_) {
+        // Already in an unrecoverable state; nothing to do.
+    }
+}
+
 export default class WebCodecsOpus extends Event {
     constructor(channels, config) {
         super('webcodecs-opus');
-        this.channels = channels || 1;
+        this.channels = channels || DEFAULT_CHANNELS;
         this.config = config || {};
         // Target output rate requested by the caller via
         // `options.sampleRate`; defaults to WebCodecs' native 48 kHz
@@ -106,16 +131,7 @@ export default class WebCodecsOpus extends Event {
             // If `new AudioDecoder()` succeeded and `configure()` threw,
             // we own a partially-constructed decoder whose underlying
             // media-process resource would otherwise leak until GC.
-            // Release it explicitly, mirroring `closeDecoder()`.
-            if (dec) {
-                try {
-                    if (dec.state !== 'closed') {
-                        dec.close();
-                    }
-                } catch (_) {
-                    // Already in an unrecoverable state; nothing to do.
-                }
-            }
+            safeCloseDecoder(dec);
             if (this.config.handleCorruptedStream) {
                 this.safeDispatch('corrupted_stream', err);
             }
@@ -140,16 +156,7 @@ export default class WebCodecsOpus extends Event {
     closeDecoder() {
         const old = this.decoder;
         this.decoder = null;
-        if (!old) {
-            return;
-        }
-        try {
-            if (old.state !== 'closed') {
-                old.close();
-            }
-        } catch (_) {
-            // Decoder is already in an unrecoverable state; nothing to do.
-        }
+        safeCloseDecoder(old);
     }
 
     getSampleRate() {
@@ -324,13 +331,7 @@ export default class WebCodecsOpus extends Event {
                 clearTimeout(timeoutHandle);
                 timeoutHandle = null;
             }
-            try {
-                if (dec.state !== 'closed') {
-                    dec.close();
-                }
-            } catch (_) {
-                // Decoder is already in an unrecoverable state; nothing to do.
-            }
+            safeCloseDecoder(dec);
             this.offAll();
         };
         let flushed;

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -53,6 +53,13 @@ import Event from './event.js';
 
 const WEBCODECS_OPUS_RATE = 48000;
 
+// Maximum number of times we'll rebuild the underlying `AudioDecoder`
+// in response to errors before giving up on the stream. `AudioDecoder`
+// transitions to 'closed' on any decode error, so to match libopus's
+// forgiving behavior we rebuild and keep going. A small upper bound
+// prevents a pathological stream from spinning forever.
+const MAX_REBUILD_ATTEMPTS = 5;
+
 export default class WebCodecsOpus extends Event {
     constructor(channels, config) {
         super('webcodecs-opus');
@@ -67,21 +74,29 @@ export default class WebCodecsOpus extends Event {
         // A per-packet 60ms step is the upper bound on an Opus frame.
         this.nextTimestamp = 0;
         this.closed = false;
+        this.rebuildAttempts = 0;
+        this.decoder = this._buildDecoder();
+    }
 
-        this.decoder = new AudioDecoder({
-            output: this._onAudioData.bind(this),
-            error: this._onError.bind(this)
-        });
-
+    _buildDecoder() {
+        let dec;
         try {
-            this.decoder.configure({
+            dec = new AudioDecoder({
+                output: this._onAudioData.bind(this),
+                error: this._onError.bind(this)
+            });
+            dec.configure({
                 codec: 'opus',
                 sampleRate: WEBCODECS_OPUS_RATE,
                 numberOfChannels: this.channels
             });
         } catch (err) {
-            this._onError(err);
+            if (this.config.handleCorruptedStream) {
+                this.dispatch('corrupted_stream', err);
+            }
+            return null;
         }
+        return dec;
     }
 
     getSampleRate() {
@@ -125,6 +140,11 @@ export default class WebCodecsOpus extends Event {
                 return;
             }
 
+            // Reset the rebuild counter on any successful output so a
+            // rare corrupted frame early in a long stream doesn't burn
+            // through the rebuild budget for the rest of the session.
+            this.rebuildAttempts = 0;
+
             // Always pull planar f32 from WebCodecs: it's the one format
             // the spec requires implementations to support, and it makes
             // the subsequent resample step channel-agnostic.
@@ -147,7 +167,9 @@ export default class WebCodecsOpus extends Event {
                 interleaved = linearResampleInterleave(planes, numFrames, numChannels, srcRate, dstRate);
             }
 
-            this.dispatch('data', interleaved);
+            if (interleaved.length > 0) {
+                this.dispatch('data', interleaved);
+            }
         } catch (err) {
             this._onError(err);
         } finally {
@@ -159,19 +181,83 @@ export default class WebCodecsOpus extends Event {
         if (this.config.handleCorruptedStream) {
             this.dispatch('corrupted_stream', err);
         }
+        if (this.closed) {
+            return;
+        }
+        // Per WebCodecs, `AudioDecoder` transitions to 'closed' on any
+        // error, which would silently drop every subsequent packet of
+        // this stream. libopus by contrast tolerates bad frames and
+        // keeps decoding the rest. Rebuild the underlying decoder so
+        // the next `decode()` call can succeed. `nextTimestamp` stays
+        // monotonic across the rebuild, which is all WebCodecs requires.
+        if (this.rebuildAttempts >= MAX_REBUILD_ATTEMPTS) {
+            this.decoder = null;
+            return;
+        }
+        this.rebuildAttempts++;
+        const old = this.decoder;
+        this.decoder = null;
+        if (old) {
+            try {
+                if (old.state !== 'closed') {
+                    old.close();
+                }
+            } catch (_) {
+                // Decoder is already dead; ignore.
+            }
+        }
+        this.decoder = this._buildDecoder();
     }
 
     destroy() {
-        this.closed = true;
-        try {
-            if (this.decoder && this.decoder.state !== 'closed') {
-                this.decoder.close();
-            }
-        } catch (_) {
-            // Best-effort cleanup; ignore teardown errors.
+        if (this.closed) {
+            return;
         }
+        this.closed = true;
+        const dec = this.decoder;
         this.decoder = null;
-        this.offAll();
+        if (!dec) {
+            this.offAll();
+            return;
+        }
+        // Drain any in-flight decodes before tearing down. `AudioDecoder.
+        // decode()` is pipelined: the output callback for each chunk fires
+        // some microtasks after the decode was issued. Calling `close()`
+        // synchronously (as the initial implementation did) aborts the
+        // pipeline and silently drops whatever `AudioData` callbacks
+        // haven't fired yet, which for an end-of-message destroy meant
+        // losing the tail of the audio. Since `stopPlayback` in the SDK
+        // computes playback duration from packet count, the player would
+        // underrun at the end and sit "stuck" waiting for PCM that never
+        // arrived.
+        //
+        // `flush()` resolves once every queued decode has produced its
+        // output (or thrown). We keep the listener list live until then
+        // so the last few `dispatch('data', ...)` calls make it through
+        // to `IncomingMessage.ondata` and into the player. After flush
+        // resolves we actually close the decoder and tear down listeners.
+        const finalize = () => {
+            try {
+                if (dec.state !== 'closed') {
+                    dec.close();
+                }
+            } catch (_) {
+                // Best-effort cleanup.
+            }
+            this.offAll();
+        };
+        let flushed;
+        try {
+            flushed = dec.flush();
+        } catch (_) {
+            finalize();
+            return;
+        }
+        if (flushed && typeof flushed.then === 'function') {
+            flushed.then(finalize, finalize);
+        } else {
+            finalize();
+        }
     }
 }
 

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -60,6 +60,14 @@ const WEBCODECS_OPUS_RATE = 48000;
 // prevents a pathological stream from spinning forever.
 const MAX_REBUILD_ATTEMPTS = 5;
 
+// Backstop for the `flush()`-then-`close()` dance in `destroy()`. In
+// healthy operation `AudioDecoder.flush()` resolves in well under a
+// millisecond, so a one-second timeout is purely a safety net for the
+// case where the audio process hangs or the promise never settles.
+// Without it, a stuck flush would retain this instance (and its event
+// listeners) for the lifetime of the page.
+const FLUSH_TIMEOUT_MS = 1000;
+
 export default class WebCodecsOpus extends Event {
     constructor(channels, config) {
         super('webcodecs-opus');
@@ -92,15 +100,52 @@ export default class WebCodecsOpus extends Event {
             });
         } catch (err) {
             if (this.config.handleCorruptedStream) {
-                this.dispatch('corrupted_stream', err);
+                this.safeDispatch('corrupted_stream', err);
             }
             return null;
         }
         return dec;
     }
 
+    // Close and null `this.decoder` in a single safe step. Used by both
+    // the rebuild path and the budget-exhausted path so the underlying
+    // `AudioDecoder` is always explicitly released (rather than left
+    // for GC, which is unreliable for media-process resources).
+    closeDecoder() {
+        const old = this.decoder;
+        this.decoder = null;
+        if (!old) {
+            return;
+        }
+        try {
+            if (old.state !== 'closed') {
+                old.close();
+            }
+        } catch {
+            // Decoder is already in an unrecoverable state; nothing to do.
+        }
+    }
+
     getSampleRate() {
         return this.outputSampleRate;
+    }
+
+    // Wrapper around `Event.dispatch` that isolates listener exceptions
+    // from our internal lifecycle. Without this, a thrown error from a
+    // consumer's `'data'` handler (e.g. a bug deep in `player.feed`)
+    // would propagate back into `onAudioData`'s catch block, get
+    // misclassified as a decoder error, and burn through the rebuild
+    // budget. Same hazard for a throwing `'corrupted_stream'`
+    // listener, which would skip the rebuild entirely and leave the
+    // stream silently dead.
+    safeDispatch(event, data) {
+        try {
+            this.dispatch(event, data);
+        } catch {
+            // Listener bug; not a decoder problem. Intentionally
+            // swallowed so we don't tear down a healthy decoder over
+            // a defect downstream.
+        }
     }
 
     decode(packet) {
@@ -168,7 +213,7 @@ export default class WebCodecsOpus extends Event {
             }
 
             if (interleaved.length > 0) {
-                this.dispatch('data', interleaved);
+                this.safeDispatch('data', interleaved);
             }
         } catch (err) {
             this.onError(err);
@@ -179,7 +224,7 @@ export default class WebCodecsOpus extends Event {
 
     onError(err) {
         if (this.config.handleCorruptedStream) {
-            this.dispatch('corrupted_stream', err);
+            this.safeDispatch('corrupted_stream', err);
         }
         if (this.closed) {
             return;
@@ -191,21 +236,21 @@ export default class WebCodecsOpus extends Event {
         // the next `decode()` call can succeed. `nextTimestamp` stays
         // monotonic across the rebuild, which is all WebCodecs requires.
         if (this.rebuildAttempts >= MAX_REBUILD_ATTEMPTS) {
-            this.decoder = null;
+            // Close the most recently-built decoder before giving up;
+            // otherwise its underlying media-process resource is left
+            // for GC, which is unreliable. Subsequent `decode()` calls
+            // become silent no-ops because `this.decoder` is null.
+            this.closeDecoder();
+            // Surface a final terminal error so consumers aren't left
+            // wondering why the stream went silent.
+            if (this.config.handleCorruptedStream) {
+                this.safeDispatch('corrupted_stream',
+                    new Error('WebCodecs decoder rebuild budget exhausted'));
+            }
             return;
         }
         this.rebuildAttempts++;
-        const old = this.decoder;
-        this.decoder = null;
-        if (old) {
-            try {
-                if (old.state !== 'closed') {
-                    old.close();
-                }
-            } catch {
-                // Decoder is already in an unrecoverable state; nothing to do.
-            }
-        }
+        this.closeDecoder();
         this.decoder = this.buildDecoder();
     }
 
@@ -236,7 +281,23 @@ export default class WebCodecsOpus extends Event {
         // so the last few `dispatch('data', ...)` calls make it through
         // to `IncomingMessage.ondata` and into the player. After flush
         // resolves we actually close the decoder and tear down listeners.
+        //
+        // The flush is also bounded by `FLUSH_TIMEOUT_MS` so a stuck or
+        // never-settling flush promise (e.g. an audio process hang)
+        // can't retain this instance and its event listeners forever.
+        // Whichever of {flush settled, timeout fired} happens first
+        // wins; the other becomes a no-op via the `finalized` guard.
+        let finalized = false;
+        let timeoutHandle = null;
         const finalize = () => {
+            if (finalized) {
+                return;
+            }
+            finalized = true;
+            if (timeoutHandle !== null) {
+                clearTimeout(timeoutHandle);
+                timeoutHandle = null;
+            }
             try {
                 if (dec.state !== 'closed') {
                     dec.close();
@@ -256,6 +317,7 @@ export default class WebCodecsOpus extends Event {
             return;
         }
         if (flushed && typeof flushed.then === 'function') {
+            timeoutHandle = setTimeout(finalize, FLUSH_TIMEOUT_MS);
             flushed.then(finalize, finalize);
         } else {
             finalize();

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -204,17 +204,31 @@ function interleave(planes, numFrames, numChannels) {
     return out;
 }
 
-// Integer-factor decimation. Opus output for voice is already effectively
-// band-limited by the encoder to well under the target Nyquist (e.g.
-// narrowband voice at 4 kHz into a 24 kHz stream has ~20 kHz of headroom),
-// so plain decimation is adequate without an additional anti-alias filter.
+// Integer-factor downsample via an N-sample block average (boxcar FIR
+// followed by decimation). This is the cheapest anti-alias filter that
+// still meaningfully outperforms plain "pick every Nth sample"
+// decimation, and requires no state across calls. For N=2 the boxcar
+// has its first null at the source Nyquist; for larger N the first null
+// is at srcRate/N which is exactly the target Nyquist. That's not a
+// brickwall, but it's adequate for voice at any of the Opus-supported
+// output rates (48k, 24k, 16k, 12k, 8k) and much better than naive
+// subsampling for wideband content squeezed into narrowband targets.
 function decimateInterleave(planes, numFrames, numChannels, decim) {
+    if (decim === 1) {
+        return interleave(planes, numFrames, numChannels);
+    }
     const outFrames = Math.floor(numFrames / decim);
     const out = new Float32Array(outFrames * numChannels);
+    const inv = 1 / decim;
     for (let i = 0; i < outFrames; i++) {
-        const srcIdx = i * decim;
+        const base = i * decim;
         for (let ch = 0; ch < numChannels; ch++) {
-            out[i * numChannels + ch] = planes[ch][srcIdx];
+            const plane = planes[ch];
+            let sum = 0;
+            for (let k = 0; k < decim; k++) {
+                sum += plane[base + k];
+            }
+            out[i * numChannels + ch] = sum * inv;
         }
     }
     return out;

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -25,13 +25,12 @@ import Event from './event.js';
 // WebCodecs' Opus decoder in Chromium only accepts `sampleRate: 48000`
 // in `AudioDecoderConfig` and always emits 48 kHz `AudioData`, even
 // though libopus itself supports returning decoded audio at 8, 12, 16,
-// 24 or 48 kHz via `opus_decoder_create(Fs, ...)`. The Zello Channels
-// SDK, however, derives the downstream player's sample rate from the
-// codec header attached to each stream and passes it in as
-// `options.sampleRate` (24 kHz for narrow-/mediumband streams, 48 kHz
-// for wideband). If we just forwarded the raw 48 kHz samples the
-// `OpusWorker` replacement would play back at half speed / an octave
-// low whenever the session picked 24 kHz.
+// 24 or 48 kHz via `opus_decoder_create(Fs, ...)`. Callers can request
+// a different output rate via `options.sampleRate` (typically driven
+// by codec metadata on the wire, e.g. 24 kHz for narrow-/mediumband
+// streams and 48 kHz for wideband). If we just forwarded the raw
+// 48 kHz samples a caller requesting 24 kHz would play back at half
+// speed / an octave low.
 //
 // To preserve drop-in behavior, we resample the WebCodecs output down
 // to `options.sampleRate` before emitting it and report that same rate
@@ -75,8 +74,9 @@ export default class WebCodecsOpus extends Event {
         super('webcodecs-opus');
         this.channels = channels || 1;
         this.config = config || {};
-        // Target output rate. Matches the rate the Zello Channels SDK's
-        // player was configured with for this stream.
+        // Target output rate requested by the caller via
+        // `options.sampleRate`; defaults to WebCodecs' native 48 kHz
+        // when unset.
         this.outputSampleRate = this.config.sampleRate || WEBCODECS_OPUS_RATE;
         // Monotonically-increasing timestamp in microseconds. WebCodecs
         // only requires input timestamps to be strictly increasing for

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -81,7 +81,9 @@ export default class WebCodecsOpus extends Event {
         // Monotonically-increasing timestamp in microseconds. WebCodecs
         // only requires input timestamps to be strictly increasing for
         // ordering; the value is not inspected by us on the output side.
-        // A per-packet 60ms step is the upper bound on an Opus frame.
+        // A per-packet 120ms step is the upper bound on a spec-compliant
+        // Opus packet (RFC 6716 sec 3.1: a packet contains 1..48 frames
+        // of 2.5/5/10/20/40/60 ms summing to <= 120 ms).
         this.nextTimestamp = 0;
         this.closed = false;
         this.rebuildAttempts = 0;
@@ -192,7 +194,7 @@ export default class WebCodecsOpus extends Event {
             this.onError(err);
             return;
         }
-        this.nextTimestamp += 60000; // 60ms in us, upper bound on an Opus frame
+        this.nextTimestamp += 120000; // 120ms in us, max Opus packet duration (RFC 6716)
 
         try {
             this.decoder.decode(chunk);

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -102,12 +102,34 @@ export default class WebCodecsOpus extends Event {
                 numberOfChannels: this.channels
             });
         } catch (err) {
+            // If `new AudioDecoder()` succeeded and `configure()` threw,
+            // we own a partially-constructed decoder whose underlying
+            // media-process resource would otherwise leak until GC.
+            // Release it explicitly, mirroring `closeDecoder()`.
+            if (dec) {
+                try {
+                    if (dec.state !== 'closed') {
+                        dec.close();
+                    }
+                } catch (_) {
+                    // Already in an unrecoverable state; nothing to do.
+                }
+            }
             if (this.config.handleCorruptedStream) {
                 this.safeDispatch('corrupted_stream', err);
             }
             return null;
         }
         return dec;
+    }
+
+    // Public-ish flag used by `OpusToPCM` to detect a `WebCodecsOpus`
+    // that failed to configure (e.g. an environment that exposes
+    // `AudioDecoder` but doesn't actually support `codec: 'opus'`).
+    // When false, the caller should treat this instance as unusable
+    // and either fall back or surface a hard failure.
+    get isSupported() {
+        return this.decoder !== null;
     }
 
     // Close and null `this.decoder` in a single safe step. Used by both

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -75,15 +75,15 @@ export default class WebCodecsOpus extends Event {
         this.nextTimestamp = 0;
         this.closed = false;
         this.rebuildAttempts = 0;
-        this.decoder = this._buildDecoder();
+        this.decoder = this.buildDecoder();
     }
 
-    _buildDecoder() {
+    buildDecoder() {
         let dec;
         try {
             dec = new AudioDecoder({
-                output: this._onAudioData.bind(this),
-                error: this._onError.bind(this)
+                output: this.onAudioData.bind(this),
+                error: this.onError.bind(this)
             });
             dec.configure({
                 codec: 'opus',
@@ -120,7 +120,7 @@ export default class WebCodecsOpus extends Event {
                 data: bytes
             });
         } catch (err) {
-            this._onError(err);
+            this.onError(err);
             return;
         }
         this.nextTimestamp += 60000; // 60ms in us, upper bound on an Opus frame
@@ -128,11 +128,11 @@ export default class WebCodecsOpus extends Event {
         try {
             this.decoder.decode(chunk);
         } catch (err) {
-            this._onError(err);
+            this.onError(err);
         }
     }
 
-    _onAudioData(audioData) {
+    onAudioData(audioData) {
         try {
             const numFrames = audioData.numberOfFrames;
             const numChannels = audioData.numberOfChannels;
@@ -171,13 +171,13 @@ export default class WebCodecsOpus extends Event {
                 this.dispatch('data', interleaved);
             }
         } catch (err) {
-            this._onError(err);
+            this.onError(err);
         } finally {
             audioData.close();
         }
     }
 
-    _onError(err) {
+    onError(err) {
         if (this.config.handleCorruptedStream) {
             this.dispatch('corrupted_stream', err);
         }
@@ -202,11 +202,11 @@ export default class WebCodecsOpus extends Event {
                 if (old.state !== 'closed') {
                     old.close();
                 }
-            } catch (_) {
-                // Decoder is already dead; ignore.
+            } catch {
+                // Decoder is already in an unrecoverable state; nothing to do.
             }
         }
-        this.decoder = this._buildDecoder();
+        this.decoder = this.buildDecoder();
     }
 
     destroy() {
@@ -241,15 +241,17 @@ export default class WebCodecsOpus extends Event {
                 if (dec.state !== 'closed') {
                     dec.close();
                 }
-            } catch (_) {
-                // Best-effort cleanup.
+            } catch {
+                // Decoder is already in an unrecoverable state; nothing to do.
             }
             this.offAll();
         };
         let flushed;
         try {
             flushed = dec.flush();
-        } catch (_) {
+        } catch {
+            // flush() rejects/throws if the decoder is already errored;
+            // skip straight to teardown.
             finalize();
             return;
         }

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -1,0 +1,182 @@
+import Event from './event.js';
+
+// Native Opus decoder backed by the browser's WebCodecs `AudioDecoder`.
+//
+// This is an opt-in alternative to the `OpusWorker` path (which spins up a
+// full Emscripten-compiled libopus bundle inside a dedicated Web Worker).
+// `AudioDecoder` runs in the user agent's media pipeline, typically off the
+// main thread and often backed by a platform codec, so it avoids:
+//
+//   - the ~918 KB inlined worker bundle and its V8 isolate,
+//   - the dynamic `eval`/`new Function` code paths Emscripten emits for
+//     `cwrap`-generated C shims, and
+//   - the per-decoder PartitionAlloc pages that don't reliably return to
+//     the OS after `worker.terminate()`.
+//
+// It is enabled via `new OpusToPCM({ useNative: true })` and only when
+// `typeof AudioDecoder !== 'undefined'`. Opus is a required codec in the
+// WebCodecs spec, so in any Chromium-based environment (notably Electron,
+// which is where Dispatch Hub lives) `AudioDecoder` + `codec: 'opus'` is
+// guaranteed to be supported. For non-Chromium environments where
+// `AudioDecoder` is missing, `OpusToPCM` falls back to `OpusWorker` when
+// `fallback: true`.
+//
+// Interface contract (matches `OpusWorker`/`Ogg`):
+//   - emits 'data'              with an interleaved Float32Array of PCM
+//   - emits 'corrupted_stream'  when a decode error is surfaced (only when
+//                               `config.handleCorruptedStream` is set)
+//   - `getSampleRate()`         returns the output sample rate
+//   - `decode(packet)`          accepts a Uint8Array/ArrayBuffer of one
+//                               Opus packet
+//   - `destroy()`               tears down the decoder
+//
+// Opus always decodes at 48 kHz. The decoder requests interleaved f32
+// output from `AudioData.copyTo` when the platform supports it and falls
+// back to copying per-plane and interleaving in JS otherwise.
+
+const OPUS_SAMPLE_RATE = 48000;
+
+export default class WebCodecsOpus extends Event {
+    constructor(channels, config) {
+        super('webcodecs-opus');
+        this.channels = channels || 1;
+        this.config = config || {};
+        this.sampleRate = OPUS_SAMPLE_RATE;
+        // Monotonically-increasing timestamp in microseconds. WebCodecs only
+        // requires input timestamps to be strictly increasing for ordering;
+        // the value itself is not inspected by us on the output side. A
+        // per-packet 60ms step is the maximum Opus frame duration and leaves
+        // headroom for any downstream consumer that does care.
+        this.nextTimestamp = 0;
+        this.closed = false;
+
+        this.decoder = new AudioDecoder({
+            output: this._onAudioData.bind(this),
+            error: this._onError.bind(this)
+        });
+
+        try {
+            this.decoder.configure({
+                codec: 'opus',
+                sampleRate: this.sampleRate,
+                numberOfChannels: this.channels
+            });
+        } catch (err) {
+            this._onError(err);
+        }
+    }
+
+    getSampleRate() {
+        return this.sampleRate;
+    }
+
+    decode(packet) {
+        if (this.closed || !this.decoder || this.decoder.state === 'closed') {
+            return;
+        }
+        const bytes = toUint8Array(packet);
+        if (!bytes || bytes.byteLength === 0) {
+            return;
+        }
+
+        let chunk;
+        try {
+            chunk = new EncodedAudioChunk({
+                type: 'key',
+                timestamp: this.nextTimestamp,
+                data: bytes
+            });
+        } catch (err) {
+            this._onError(err);
+            return;
+        }
+        this.nextTimestamp += 60000; // 60ms in us; upper bound on an Opus frame
+
+        try {
+            this.decoder.decode(chunk);
+        } catch (err) {
+            this._onError(err);
+        }
+    }
+
+    _onAudioData(audioData) {
+        try {
+            const numFrames = audioData.numberOfFrames;
+            const numChannels = audioData.numberOfChannels;
+            if (!numFrames || !numChannels) {
+                return;
+            }
+
+            const interleaved = new Float32Array(numFrames * numChannels);
+
+            // Fast path: ask the UA for interleaved f32 directly.
+            let gotInterleaved = false;
+            if (numChannels === 1) {
+                try {
+                    audioData.copyTo(interleaved, {planeIndex: 0, format: 'f32'});
+                    gotInterleaved = true;
+                } catch (_) {
+                    // Fall through to planar copy.
+                }
+            } else {
+                try {
+                    audioData.copyTo(interleaved, {planeIndex: 0, format: 'f32'});
+                    gotInterleaved = true;
+                } catch (_) {
+                    // Not all implementations expose 'f32'; fall back to planar.
+                }
+            }
+
+            if (!gotInterleaved) {
+                for (let ch = 0; ch < numChannels; ch++) {
+                    const plane = new Float32Array(numFrames);
+                    audioData.copyTo(plane, {planeIndex: ch, format: 'f32-planar'});
+                    for (let i = 0; i < numFrames; i++) {
+                        interleaved[i * numChannels + ch] = plane[i];
+                    }
+                }
+            }
+
+            this.dispatch('data', interleaved);
+        } catch (err) {
+            this._onError(err);
+        } finally {
+            audioData.close();
+        }
+    }
+
+    _onError(err) {
+        if (this.config.handleCorruptedStream) {
+            this.dispatch('corrupted_stream', err);
+        }
+    }
+
+    destroy() {
+        this.closed = true;
+        try {
+            if (this.decoder && this.decoder.state !== 'closed') {
+                this.decoder.close();
+            }
+        } catch (_) {
+            // Best-effort cleanup; ignore teardown errors.
+        }
+        this.decoder = null;
+        this.offAll();
+    }
+}
+
+function toUint8Array(packet) {
+    if (!packet) {
+        return null;
+    }
+    if (packet instanceof Uint8Array) {
+        return packet;
+    }
+    if (packet instanceof ArrayBuffer) {
+        return new Uint8Array(packet);
+    }
+    if (ArrayBuffer.isView(packet)) {
+        return new Uint8Array(packet.buffer, packet.byteOffset, packet.byteLength);
+    }
+    return null;
+}

--- a/src/utils/webcodecs-opus.js
+++ b/src/utils/webcodecs-opus.js
@@ -101,8 +101,16 @@ export default class WebCodecsOpus extends Event {
         this.config = config || {};
         // Target output rate requested by the caller via
         // `options.sampleRate`; defaults to WebCodecs' native 48 kHz
-        // when unset.
-        this.outputSampleRate = this.config.sampleRate || WEBCODECS_OPUS_RATE;
+        // when unset, malformed (string, NaN), or non-positive. The
+        // coercion matters because `onAudioData` does
+        // `srcRate % dstRate === 0` to pick the integer-decimation
+        // branch, and `48000 % "abc"` / `48000 % undefined` is `NaN`
+        // (`NaN === 0` is false), which would silently route every
+        // packet through the linear-interpolation fallback.
+        const requestedRate = Number(this.config.sampleRate);
+        this.outputSampleRate = Number.isFinite(requestedRate) && requestedRate > 0
+            ? requestedRate
+            : WEBCODECS_OPUS_RATE;
         // Monotonically-increasing timestamp in microseconds. WebCodecs
         // only requires input timestamps to be strictly increasing for
         // ordering; the value is not inspected by us on the output side.

--- a/test/webcodecs-opus-integration.js
+++ b/test/webcodecs-opus-integration.js
@@ -26,7 +26,7 @@ const HAS_ENCODER = typeof window.AudioEncoder !== 'undefined' &&
             // The whole point of the native path: this combo is
             // mandatory by spec on every WebCodecs implementation.
             // If a future Chromium build changes that, we want to
-            // know in CI rather than at runtime in Dispatch Hub.
+            // know in CI rather than at runtime.
             const dec = new WebCodecsOpus(1, {sampleRate: 48000});
             ok(dec.decoder, 'decoder constructed');
             equal(dec.decoder.state, 'configured');

--- a/test/webcodecs-opus-integration.js
+++ b/test/webcodecs-opus-integration.js
@@ -1,0 +1,295 @@
+import {equal, ok} from 'assert';
+import WebCodecsOpus from '../src/utils/webcodecs-opus.js';
+
+// End-to-end integration tests against the real WebCodecs API.
+//
+// These verify that the assumptions baked into WebCodecsOpus actually
+// hold against a real `AudioDecoder` (not just a fake): the codec
+// string we ship, the channel count, the timestamp scheme, the
+// flush-then-close lifecycle, and the bit format we ask for in copyTo.
+// Most lifecycle/state-machine concerns are covered by the unit suite
+// using fakes, so this file stays small and deliberately doesn't try
+// to re-test things that don't depend on the real implementation.
+//
+// Suites are skipped (rather than failing) on browsers that don't
+// expose AudioDecoder/AudioEncoder. Karma is currently configured for
+// Chrome which ships both, but if anyone points karma at Firefox the
+// suite shouldn't break; it should just no-op.
+
+const HAS_DECODER = typeof window.AudioDecoder !== 'undefined';
+const HAS_ENCODER = typeof window.AudioEncoder !== 'undefined' &&
+                    typeof window.AudioData !== 'undefined';
+
+(HAS_DECODER ? describe : describe.skip)(
+    'WebCodecsOpus integration -- real AudioDecoder', function() {
+        it('configures successfully with codec=opus, sr=48000, channels=1', function() {
+            // The whole point of the native path: this combo is
+            // mandatory by spec on every WebCodecs implementation.
+            // If a future Chromium build changes that, we want to
+            // know in CI rather than at runtime in Dispatch Hub.
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            ok(dec.decoder, 'decoder constructed');
+            equal(dec.decoder.state, 'configured');
+            dec.destroy();
+        });
+
+        it('supports stereo configuration', function() {
+            const dec = new WebCodecsOpus(2, {sampleRate: 48000});
+            equal(dec.decoder.state, 'configured');
+            dec.destroy();
+        });
+
+        it('reports the requested output sample rate even when WebCodecs always emits 48k', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 24000});
+            equal(dec.getSampleRate(), 24000);
+            dec.destroy();
+        });
+
+        it('destroy() completes (flush settles) on an empty decoder', function(done) {
+            this.timeout(2000);
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const fakeDecoder = dec.decoder;
+            dec.destroy();
+            // Poll until the real decoder is closed. Should be ~ms.
+            const start = Date.now();
+            (function check() {
+                if (fakeDecoder.state === 'closed') {
+                    done();
+                    return;
+                }
+                if (Date.now() - start > 1500) {
+                    done(new Error('decoder did not close within 1500ms; state=' + fakeDecoder.state));
+                    return;
+                }
+                setTimeout(check, 10);
+            })();
+        });
+
+        // Note: we deliberately don't have an integration test that
+        // hands "garbage" bytes to the real decoder and asserts a
+        // corrupted_stream event. Opus is designed to be extremely
+        // tolerant of bad input (it's part of the spec), so what
+        // counts as "garbage enough to error" is fragile and
+        // implementation-specific. The error/rebuild/budget pathway
+        // is exercised deterministically by the lifecycle suite
+        // against the fake decoder, which is the right place for
+        // those assertions.
+    });
+
+(HAS_DECODER && HAS_ENCODER ? describe : describe.skip)(
+    'WebCodecsOpus integration -- end-to-end encode/decode roundtrip', function() {
+
+        function makeAudioData(samples, sampleRate, timestamp) {
+            // Build a single-channel f32-planar AudioData from a
+            // Float32Array. WebCodecs requires a full copy of `data`
+            // here, so the typed-array can be reused.
+            return new AudioData({
+                format: 'f32-planar',
+                sampleRate: sampleRate,
+                numberOfFrames: samples.length,
+                numberOfChannels: 1,
+                timestamp: timestamp,
+                data: samples
+            });
+        }
+
+        function rms(arr) {
+            let s = 0;
+            for (let i = 0; i < arr.length; i++) {
+                s += arr[i] * arr[i];
+            }
+            return Math.sqrt(s / arr.length);
+        }
+
+        it('decodes Opus packets produced by the same browser\'s AudioEncoder', function(done) {
+            // Ground-truth integration. We encode a 1 kHz sine via
+            // AudioEncoder, hand the encoded packets to WebCodecsOpus,
+            // and verify we get out PCM with non-trivial energy at
+            // roughly the right total length. We don't compare
+            // sample-by-sample because Opus is lossy and inserts
+            // codec lookahead; we'd just be testing libopus.
+            this.timeout(5000);
+
+            const SR = 48000;
+            const FRAME_MS = 20; // 20ms frame, 960 samples at 48k
+            const FRAME_SAMPLES = (SR / 1000) * FRAME_MS;
+            const NUM_FRAMES = 10; // 200 ms of audio
+
+            const encodedChunks = [];
+            let encodeError = null;
+
+            const encoder = new AudioEncoder({
+                output: function(chunk) {
+                    encodedChunks.push(chunk);
+                },
+                error: function(err) { encodeError = err; }
+            });
+            encoder.configure({
+                codec: 'opus',
+                sampleRate: SR,
+                numberOfChannels: 1,
+                bitrate: 32000
+            });
+
+            // Synthesize and encode NUM_FRAMES of 1kHz sine.
+            const tone = new Float32Array(FRAME_SAMPLES);
+            const frequency = 1000;
+            for (let f = 0; f < NUM_FRAMES; f++) {
+                for (let i = 0; i < FRAME_SAMPLES; i++) {
+                    const t = (f * FRAME_SAMPLES + i) / SR;
+                    tone[i] = Math.sin(2 * Math.PI * frequency * t) * 0.5;
+                }
+                const data = makeAudioData(tone.slice(), SR, (f * FRAME_MS * 1000));
+                encoder.encode(data);
+                data.close();
+            }
+
+            encoder.flush().then(function() {
+                if (encodeError) {
+                    return done(encodeError);
+                }
+                ok(encodedChunks.length >= NUM_FRAMES,
+                    'encoder produced at least one chunk per input frame (got '
+                        + encodedChunks.length + ')');
+
+                // Now decode through WebCodecsOpus.
+                const dec = new WebCodecsOpus(1, {sampleRate: SR});
+                const pcmChunks = [];
+                dec.on('data', function(buf) { pcmChunks.push(buf); });
+
+                for (let i = 0; i < encodedChunks.length; i++) {
+                    const chunk = encodedChunks[i];
+                    const bytes = new Uint8Array(chunk.byteLength);
+                    chunk.copyTo(bytes);
+                    dec.decode(bytes);
+                }
+
+                // The real AudioDecoder pipelines its work; destroy()
+                // flushes and waits for tail PCM, so we await it.
+                // destroy() doesn't return a promise so we poll via
+                // a 'data' settle window.
+                const settleStart = Date.now();
+                (function awaitTail() {
+                    const before = pcmChunks.length;
+                    setTimeout(function() {
+                        if (pcmChunks.length === before || Date.now() - settleStart > 2000) {
+                            try {
+                                let totalSamples = 0;
+                                for (let i = 0; i < pcmChunks.length; i++) {
+                                    totalSamples += pcmChunks[i].length;
+                                }
+                                ok(totalSamples > 0, 'got PCM out (samples=' + totalSamples + ')');
+                                ok(totalSamples >= FRAME_SAMPLES * NUM_FRAMES * 0.8,
+                                    'PCM count is roughly the expected length (got '
+                                        + totalSamples + ', expected ~'
+                                        + FRAME_SAMPLES * NUM_FRAMES + ')');
+
+                                // Verify the decoded audio actually
+                                // carries energy. A silent decoder bug
+                                // would drop this to ~0.
+                                const all = new Float32Array(totalSamples);
+                                let off = 0;
+                                for (let i = 0; i < pcmChunks.length; i++) {
+                                    all.set(pcmChunks[i], off);
+                                    off += pcmChunks[i].length;
+                                }
+                                const energy = rms(all);
+                                ok(energy > 0.05,
+                                    'decoded RMS resembles a sine (got ' + energy + ')');
+
+                                dec.destroy();
+                                done();
+                            } catch (e) {
+                                done(e);
+                            }
+                        } else {
+                            awaitTail();
+                        }
+                    }, 50);
+                })();
+            }).catch(done);
+        });
+
+        it('roundtrips with downsampled output (24 kHz target)', function(done) {
+            // Regression test for the original "low pitched and slow"
+            // bug: encoder produces 48 kHz data, decoder is asked to
+            // emit at 24 kHz, and the resample step has to halve the
+            // sample count and keep RMS energy intact.
+            this.timeout(5000);
+
+            const SR_IN = 48000;
+            const SR_OUT = 24000;
+            const FRAME_SAMPLES = 960; // 20ms at 48k
+            const NUM_FRAMES = 10;
+
+            const encodedChunks = [];
+            const encoder = new AudioEncoder({
+                output: function(c) { encodedChunks.push(c); },
+                error: function(err) { done(err); }
+            });
+            encoder.configure({
+                codec: 'opus',
+                sampleRate: SR_IN,
+                numberOfChannels: 1,
+                bitrate: 32000
+            });
+
+            const tone = new Float32Array(FRAME_SAMPLES);
+            for (let f = 0; f < NUM_FRAMES; f++) {
+                for (let i = 0; i < FRAME_SAMPLES; i++) {
+                    const t = (f * FRAME_SAMPLES + i) / SR_IN;
+                    tone[i] = Math.sin(2 * Math.PI * 1000 * t) * 0.5;
+                }
+                const data = makeAudioData(tone.slice(), SR_IN, f * 20000);
+                encoder.encode(data);
+                data.close();
+            }
+
+            encoder.flush().then(function() {
+                const dec = new WebCodecsOpus(1, {sampleRate: SR_OUT});
+                const pcmChunks = [];
+                dec.on('data', function(buf) { pcmChunks.push(buf); });
+
+                for (let i = 0; i < encodedChunks.length; i++) {
+                    const c = encodedChunks[i];
+                    const bytes = new Uint8Array(c.byteLength);
+                    c.copyTo(bytes);
+                    dec.decode(bytes);
+                }
+
+                setTimeout(function() {
+                    try {
+                        let total = 0;
+                        for (let i = 0; i < pcmChunks.length; i++) {
+                            total += pcmChunks[i].length;
+                        }
+                        // Output should be roughly half the 48k frame
+                        // count -- not exactly, because Opus lookahead
+                        // and any tail PCM also passes through the
+                        // resampler.
+                        const expected48k = FRAME_SAMPLES * NUM_FRAMES;
+                        ok(total > expected48k * 0.4 && total < expected48k * 0.7,
+                            'output is roughly half the source samples ('
+                                + total + ' vs expected ~' + expected48k / 2 + ')');
+
+                        // Must still carry energy: the decimation
+                        // would zero this out only if the boxcar
+                        // lost its 1/N normalization or we dropped
+                        // every sample.
+                        const all = new Float32Array(total);
+                        let off = 0;
+                        for (let i = 0; i < pcmChunks.length; i++) {
+                            all.set(pcmChunks[i], off);
+                            off += pcmChunks[i].length;
+                        }
+                        ok(rms(all) > 0.05, 'decimated output still has energy');
+
+                        dec.destroy();
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                }, 500);
+            }).catch(done);
+        });
+    });

--- a/test/webcodecs-opus-integration.js
+++ b/test/webcodecs-opus-integration.js
@@ -145,6 +145,12 @@ const HAS_ENCODER = typeof window.AudioEncoder !== 'undefined' &&
             }
 
             encoder.flush().then(function() {
+                // Release the encoder's native resource as soon as we
+                // have all the chunks. WebCodecs encoders are not
+                // garbage-collected aggressively across Karma runs, so
+                // leaving them open across tests can exhaust the
+                // browser's media-process slots.
+                try { encoder.close(); } catch (_) {}
                 if (encodeError) {
                     return done(encodeError);
                 }
@@ -225,7 +231,10 @@ const HAS_ENCODER = typeof window.AudioEncoder !== 'undefined' &&
             const encodedChunks = [];
             const encoder = new AudioEncoder({
                 output: function(c) { encodedChunks.push(c); },
-                error: function(err) { done(err); }
+                error: function(err) {
+                    try { encoder.close(); } catch (_) {}
+                    done(err);
+                }
             });
             encoder.configure({
                 codec: 'opus',
@@ -246,6 +255,7 @@ const HAS_ENCODER = typeof window.AudioEncoder !== 'undefined' &&
             }
 
             encoder.flush().then(function() {
+                try { encoder.close(); } catch (_) {}
                 const dec = new WebCodecsOpus(1, {sampleRate: SR_OUT});
                 const pcmChunks = [];
                 dec.on('data', function(buf) { pcmChunks.push(buf); });

--- a/test/webcodecs-opus-integration.js
+++ b/test/webcodecs-opus-integration.js
@@ -303,3 +303,357 @@ const HAS_ENCODER = typeof window.AudioEncoder !== 'undefined' &&
             }).catch(done);
         });
     });
+
+// Helpers for the frame-size coverage suite below. Kept module-level
+// so individual tests stay readable.
+
+function makeMonoSine(samples, sampleRate, frequency, gain, frameOffset) {
+    // Phase-continuous so concatenating clips doesn't introduce
+    // discontinuities that leak energy into other bands. Tests don't
+    // strictly need that but it's nicer for energy assertions.
+    const out = new Float32Array(samples);
+    for (let i = 0; i < samples; i++) {
+        const t = (frameOffset + i) / sampleRate;
+        out[i] = Math.sin(2 * Math.PI * frequency * t) * gain;
+    }
+    return out;
+}
+
+function rmsFlat(arr) {
+    let s = 0;
+    for (let i = 0; i < arr.length; i++) {
+        s += arr[i] * arr[i];
+    }
+    return Math.sqrt(s / arr.length);
+}
+
+// Encode `numFrames` of a 1 kHz sine at the requested Opus frame
+// duration, then call back with the EncodedAudioChunk array. Hides
+// the AudioEncoder dance so each test reads as one assertion.
+function encodeSineToOpus(opts, cb) {
+    const sampleRate = opts.sampleRate;
+    const frameDurationUs = opts.frameDurationUs;
+    const numFrames = opts.numFrames;
+    const frameSamples = (sampleRate * frameDurationUs) / 1000000;
+    const chunks = [];
+    let encodeError = null;
+
+    const encoder = new AudioEncoder({
+        output: function(c) { chunks.push(c); },
+        error: function(err) { encodeError = err; }
+    });
+    try {
+        encoder.configure({
+            codec: 'opus',
+            sampleRate: sampleRate,
+            numberOfChannels: 1,
+            bitrate: 32000,
+            opus: {frameDuration: frameDurationUs}
+        });
+    } catch (err) {
+        return cb(err);
+    }
+
+    for (let f = 0; f < numFrames; f++) {
+        const tone = makeMonoSine(frameSamples, sampleRate, 1000, 0.5,
+            f * frameSamples);
+        const ad = new AudioData({
+            format: 'f32-planar',
+            sampleRate: sampleRate,
+            numberOfFrames: frameSamples,
+            numberOfChannels: 1,
+            timestamp: f * frameDurationUs,
+            data: tone
+        });
+        encoder.encode(ad);
+        ad.close();
+    }
+
+    encoder.flush().then(function() {
+        try { encoder.close(); } catch (_) {}
+        if (encodeError) {
+            return cb(encodeError);
+        }
+        cb(null, chunks, frameSamples * numFrames);
+    }).catch(cb);
+}
+
+// Construct a code-2 (two-frame VBR) Opus packet by splicing two
+// existing single-frame packets under a shared TOC. Per RFC 6716
+// sec 3.1, all frames in a multi-frame packet must share config,
+// which is guaranteed when both inputs came from the same encoder
+// configuration. The body bytes after the TOC carry the raw Opus
+// frame payload, which can be concatenated under a new TOC.
+function packTwoFrameOpus(p1, p2) {
+    // p1, p2 are Uint8Arrays representing single-frame packets.
+    const toc = (p1[0] & 0xFC) | 0x02; // c=2 (two frames, VBR)
+    const body1 = p1.subarray(1);
+    const body2 = p2.subarray(1);
+    const len1 = body1.length;
+    if (len1 >= 252) {
+        // Two-byte length encoding exists in the spec but our
+        // synthetic test uses small sine clips that always fit in
+        // the one-byte form. Bail loudly if that assumption breaks
+        // (e.g. someone bumps the bitrate above ~250 kbps in a
+        // 60 ms frame and these get bigger).
+        throw new Error('packTwoFrameOpus: frame body too large for 1-byte len prefix');
+    }
+    const out = new Uint8Array(2 + len1 + body2.length);
+    out[0] = toc;
+    out[1] = len1;
+    out.set(body1, 2);
+    out.set(body2, 2 + len1);
+    return out;
+}
+
+// Drain `decoder` until it stops emitting `data` events for `quietMs`
+// or until `timeoutMs` elapses, then call cb with the accumulated
+// PCM array. Mirrors the settle-window pattern used in the older
+// roundtrip tests so multi-test files stay consistent.
+function drainDecoder(decoder, quietMs, timeoutMs, cb) {
+    const pcmChunks = [];
+    decoder.on('data', function(buf) { pcmChunks.push(buf); });
+    const start = Date.now();
+    let lastSize = -1;
+    (function poll() {
+        const now = Date.now();
+        if (pcmChunks.length === lastSize) {
+            // Haven't received anything new since last poll; give it
+            // a quiet window before declaring drain complete.
+            return cb(null, pcmChunks);
+        }
+        if (now - start > timeoutMs) {
+            return cb(new Error('drain timed out (' + timeoutMs + 'ms); chunks=' + pcmChunks.length));
+        }
+        lastSize = pcmChunks.length;
+        setTimeout(poll, quietMs);
+    })();
+}
+
+(HAS_DECODER && HAS_ENCODER ? describe : describe.skip)(
+    'WebCodecsOpus integration -- frame size coverage', function() {
+        // RFC 6716 sec 2.1.4 lets Opus packets carry frames of 2.5,
+        // 5, 10, 20, 40, or 60 ms, and sec 3.1 lets a single packet
+        // chain 1..48 frames totaling up to 120 ms. Our existing
+        // roundtrip tests only exercise the 20 ms single-frame case,
+        // which is the most common but not the only valid input.
+        // These tests confirm that the decoder pipeline keeps PCM
+        // flowing for every spec-legal frame duration and for the
+        // multi-frame packing modes -- i.e. nothing in our timestamp
+        // accounting or settle logic stalls when the actual packet
+        // duration differs from a single 20 ms frame.
+
+        // AudioEncoder doesn't expose 2.5 ms in the OpusEncoderConfig
+        // (it's CELT-only and most engines refuse to configure it),
+        // so the smallest duration we can roundtrip is 5 ms.
+        const FRAME_DURATIONS_US = [5000, 10000, 20000, 40000, 60000];
+
+        FRAME_DURATIONS_US.forEach(function(frameDurationUs) {
+            const frameMs = frameDurationUs / 1000;
+            it('roundtrips ' + frameMs + 'ms-frame packets without stalling',
+                function(done) {
+                    this.timeout(5000);
+                    const SR = 48000;
+                    // Aim for ~240 ms of audio at every duration so
+                    // 60 ms gets enough packets to be meaningful and
+                    // 5 ms doesn't take forever.
+                    const numFrames = Math.max(4, Math.floor(240 / frameMs));
+                    encodeSineToOpus({
+                        sampleRate: SR,
+                        frameDurationUs: frameDurationUs,
+                        numFrames: numFrames
+                    }, function(err, chunks, expectedSamples) {
+                        if (err) return done(err);
+                        ok(chunks.length >= numFrames,
+                            'encoder produced one chunk per input frame');
+
+                        const dec = new WebCodecsOpus(1, {sampleRate: SR});
+                        for (let i = 0; i < chunks.length; i++) {
+                            const bytes = new Uint8Array(chunks[i].byteLength);
+                            chunks[i].copyTo(bytes);
+                            dec.decode(bytes);
+                        }
+
+                        drainDecoder(dec, 200, 3000, function(drainErr, pcm) {
+                            if (drainErr) {
+                                dec.destroy();
+                                return done(drainErr);
+                            }
+                            try {
+                                let total = 0;
+                                for (let i = 0; i < pcm.length; i++) {
+                                    total += pcm[i].length;
+                                }
+                                // Allow 30% slack: Opus inserts codec
+                                // delay/lookahead and the tail flush
+                                // pulls a partial frame at the end.
+                                ok(total >= expectedSamples * 0.7,
+                                    frameMs + 'ms frames produced enough PCM (got '
+                                        + total + ', expected ~' + expectedSamples + ')');
+
+                                const all = new Float32Array(total);
+                                let off = 0;
+                                for (let i = 0; i < pcm.length; i++) {
+                                    all.set(pcm[i], off);
+                                    off += pcm[i].length;
+                                }
+                                ok(rmsFlat(all) > 0.05,
+                                    frameMs + 'ms frames produced energy');
+
+                                dec.destroy();
+                                done();
+                            } catch (e) {
+                                dec.destroy();
+                                done(e);
+                            }
+                        });
+                    });
+                });
+        });
+
+        it('keeps PCM flowing across mixed frame durations in one stream',
+            function(done) {
+                // A real sender or repackager may emit a stream whose
+                // packets vary in frame duration, e.g. an adaptive
+                // encoder that uses 60 ms during low-activity periods
+                // and 20 ms during speech. The decoder should never
+                // stall regardless of the previous or next packet's
+                // duration. We can't easily reconfigure AudioEncoder
+                // mid-stream, so we encode each duration into its own
+                // clip and concatenate the chunk lists.
+                this.timeout(8000);
+                const SR = 48000;
+                const durationsMs = [10, 60, 20, 40, 5];
+                const allChunks = [];
+                let expectedTotal = 0;
+
+                (function next(i) {
+                    if (i >= durationsMs.length) {
+                        return decodeSequence();
+                    }
+                    encodeSineToOpus({
+                        sampleRate: SR,
+                        frameDurationUs: durationsMs[i] * 1000,
+                        numFrames: 4
+                    }, function(err, chunks, expected) {
+                        if (err) return done(err);
+                        for (let k = 0; k < chunks.length; k++) {
+                            allChunks.push(chunks[k]);
+                        }
+                        expectedTotal += expected;
+                        next(i + 1);
+                    });
+                })(0);
+
+                function decodeSequence() {
+                    const dec = new WebCodecsOpus(1, {sampleRate: SR});
+                    for (let i = 0; i < allChunks.length; i++) {
+                        const bytes = new Uint8Array(allChunks[i].byteLength);
+                        allChunks[i].copyTo(bytes);
+                        dec.decode(bytes);
+                    }
+                    drainDecoder(dec, 200, 4000, function(err, pcm) {
+                        if (err) {
+                            dec.destroy();
+                            return done(err);
+                        }
+                        try {
+                            let total = 0;
+                            for (let i = 0; i < pcm.length; i++) {
+                                total += pcm[i].length;
+                            }
+                            // Each duration adds its own codec delay, so
+                            // mixed-stream slack is wider than the
+                            // per-duration test.
+                            ok(total >= expectedTotal * 0.6,
+                                'mixed-duration stream produced enough PCM (got '
+                                    + total + ', expected ~' + expectedTotal + ')');
+                            dec.destroy();
+                            done();
+                        } catch (e) {
+                            dec.destroy();
+                            done(e);
+                        }
+                    });
+                }
+            });
+
+        it('decodes a hand-crafted code-2 (two-frame) Opus packet',
+            function(done) {
+                // RFC 6716 sec 3.1 lets one packet carry up to 48
+                // frames totaling up to 120 ms. AudioEncoder always
+                // emits code-0 (one-frame) packets, so to exercise
+                // the multi-frame path we splice two single-frame
+                // packets into one code-2 packet by hand. If the
+                // decoder pipeline silently dropped the second frame
+                // (or stalled waiting for a "real" packet boundary),
+                // the asserted PCM count would land near a single-
+                // frame's worth instead of two.
+                this.timeout(5000);
+                const SR = 48000;
+                const FRAME_MS = 20;
+                encodeSineToOpus({
+                    sampleRate: SR,
+                    frameDurationUs: FRAME_MS * 1000,
+                    numFrames: 2
+                }, function(err, chunks) {
+                    if (err) return done(err);
+                    if (chunks.length < 2) {
+                        return done(new Error('encoder produced fewer chunks than expected'));
+                    }
+
+                    const p1 = new Uint8Array(chunks[0].byteLength);
+                    chunks[0].copyTo(p1);
+                    const p2 = new Uint8Array(chunks[1].byteLength);
+                    chunks[1].copyTo(p2);
+
+                    let packed;
+                    try {
+                        packed = packTwoFrameOpus(p1, p2);
+                    } catch (e) {
+                        return done(e);
+                    }
+
+                    const dec = new WebCodecsOpus(1, {sampleRate: SR});
+                    dec.decode(packed);
+
+                    drainDecoder(dec, 200, 3000, function(drainErr, pcm) {
+                        if (drainErr) {
+                            dec.destroy();
+                            return done(drainErr);
+                        }
+                        try {
+                            let total = 0;
+                            for (let i = 0; i < pcm.length; i++) {
+                                total += pcm[i].length;
+                            }
+                            const oneFrameSamples = (SR * FRAME_MS) / 1000;
+                            // Two frames packed into one packet ought
+                            // to produce ~2x the PCM of a single
+                            // frame. Codec delay still applies once
+                            // for the packet, so assert >= 1.4x as a
+                            // generous floor; a "stuck after first
+                            // frame" bug would land near 1.0x.
+                            ok(total >= oneFrameSamples * 1.4,
+                                'code-2 packet produced ~2 frames worth of PCM (got '
+                                    + total + ', expected >= ' + (oneFrameSamples * 1.4) + ')');
+
+                            const all = new Float32Array(total);
+                            let off = 0;
+                            for (let i = 0; i < pcm.length; i++) {
+                                all.set(pcm[i], off);
+                                off += pcm[i].length;
+                            }
+                            ok(rmsFlat(all) > 0.05,
+                                'code-2 packet produced energy');
+
+                            dec.destroy();
+                            done();
+                        } catch (e) {
+                            dec.destroy();
+                            done(e);
+                        }
+                    });
+                });
+            });
+    });

--- a/test/webcodecs-opus-lifecycle.js
+++ b/test/webcodecs-opus-lifecycle.js
@@ -370,7 +370,7 @@ describe('WebCodecsOpus lifecycle --', function() {
             // counter doesn't reset on rebuild.
             const dec = new WebCodecsOpus(1, {sampleRate: 48000});
             const before = dec.nextTimestamp;
-            dec.decode(new Uint8Array([1])); // bumps to 60000
+            dec.decode(new Uint8Array([1])); // bumps by max packet duration
             fakes[0].fireError(new Error('boom')); // rebuild
             ok(dec.nextTimestamp > before);
         });

--- a/test/webcodecs-opus-lifecycle.js
+++ b/test/webcodecs-opus-lifecycle.js
@@ -166,6 +166,20 @@ describe('WebCodecsOpus lifecycle --', function() {
             equal(dec.getSampleRate(), 48000);
         });
 
+        it('coerces a malformed sampleRate to 48000', function() {
+            // A non-numeric or non-positive `sampleRate` would otherwise
+            // poison the `srcRate % dstRate === 0` decimation branch in
+            // `onAudioData`: `48000 % "abc"` and `48000 % undefined` are
+            // both `NaN`, which silently routes every packet through the
+            // linear-interpolation fallback. The constructor coerces
+            // bad input to the WebCodecs native rate so that branch is
+            // guaranteed to see a positive integer.
+            equal(new WebCodecsOpus(1, {sampleRate: 'abc'}).getSampleRate(), 48000);
+            equal(new WebCodecsOpus(1, {sampleRate: 0}).getSampleRate(), 48000);
+            equal(new WebCodecsOpus(1, {sampleRate: -1}).getSampleRate(), 48000);
+            equal(new WebCodecsOpus(1, {sampleRate: NaN}).getSampleRate(), 48000);
+        });
+
         it('survives a configure() that throws synchronously', function() {
             // Simulates "browser refuses our config" (e.g. a future
             // Chrome that drops Opus support, or a misconfigured

--- a/test/webcodecs-opus-lifecycle.js
+++ b/test/webcodecs-opus-lifecycle.js
@@ -179,9 +179,33 @@ describe('WebCodecsOpus lifecycle --', function() {
             try {
                 const dec = new WebCodecsOpus(1, {sampleRate: 48000});
                 equal(dec.decoder, null);
+                // The partially-built AudioDecoder must be closed
+                // explicitly so its native handle isn't leaked to GC.
+                equal(fakes[0].closeCount, 1, 'partial decoder closed');
                 // decode() on a null decoder is a no-op (no throw).
                 dec.decode(new Uint8Array([1, 2, 3]));
                 dec.destroy();
+            } finally {
+                FakeAudioDecoder.prototype.configure = realConfigure;
+            }
+        });
+
+        it('reports isSupported correctly', function() {
+            // Used by OpusToPCM to decide whether to fall back to
+            // the worker path when WebCodecs claimed support at the
+            // global level but configure() rejected our config.
+            const ok_ = new WebCodecsOpus(1, {sampleRate: 48000});
+            equal(ok_.isSupported, true);
+            ok_.destroy();
+
+            const realConfigure = FakeAudioDecoder.prototype.configure;
+            FakeAudioDecoder.prototype.configure = function() {
+                throw new Error('not supported');
+            };
+            try {
+                const bad = new WebCodecsOpus(1, {sampleRate: 48000});
+                equal(bad.isSupported, false);
+                bad.destroy();
             } finally {
                 FakeAudioDecoder.prototype.configure = realConfigure;
             }

--- a/test/webcodecs-opus-lifecycle.js
+++ b/test/webcodecs-opus-lifecycle.js
@@ -1,0 +1,590 @@
+import {equal, ok, strictEqual, deepEqual} from 'assert';
+import WebCodecsOpus, {FLUSH_TIMEOUT_MS} from '../src/utils/webcodecs-opus.js';
+
+// Lifecycle tests for WebCodecsOpus. Real `AudioDecoder` is replaced
+// with a controllable fake so we can:
+//
+//   - drive `output` and `error` callbacks deterministically,
+//   - decide when (and whether) `flush()` resolves,
+//   - assert close()/state behavior without depending on a real
+//     media-process backend.
+//
+// The fakes are installed in `beforeEach` and torn down in
+// `afterEach`. The integration suite uses the real WebCodecs API.
+
+let originalAudioDecoder;
+let originalEncodedAudioChunk;
+
+class FakeAudioData {
+    // Minimal stand-in for the parts of WebCodecs.AudioData we touch.
+    // `fillPlanes(planeIndex, dst)` lets each test inject whatever
+    // sample values it wants into the typed-array dst.
+    constructor({frames, channels, rate, fillPlanes}) {
+        this.numberOfFrames = frames;
+        this.numberOfChannels = channels;
+        this.sampleRate = rate;
+        this.format = 'f32-planar';
+        this._fillPlanes = fillPlanes || function() {};
+        this.closeCount = 0;
+    }
+    copyTo(dst, opts) {
+        this._fillPlanes(opts.planeIndex, dst);
+    }
+    close() {
+        this.closeCount++;
+    }
+}
+
+class FakeEncodedAudioChunk {
+    constructor(opts) {
+        this.type = opts.type;
+        this.timestamp = opts.timestamp;
+        this.data = opts.data;
+    }
+}
+
+// Per-test set of created fakes; lets a test inspect every instance,
+// not just the most recent.
+let fakes;
+
+class FakeAudioDecoder {
+    constructor({output, error}) {
+        this._output = output;
+        this._error = error;
+        this.state = 'unconfigured';
+        this.configureCount = 0;
+        this.decodeCount = 0;
+        this.closeCount = 0;
+        this.flushCount = 0;
+        // Pending flush deferred. Tests reach in to resolve/reject.
+        this._pendingFlush = null;
+        // Knobs the test can set before triggering behavior.
+        this.configureThrows = null;
+        this.decodeThrows = null;
+        this.flushThrowsSync = null;
+        // If true, fireError() leaves state untouched -- simulates a
+        // hypothetically non-spec-compliant implementation. Lets us
+        // verify that closeDecoder() actually closes such a decoder
+        // rather than relying on the spec to have transitioned for us.
+        this.errorLeavesStateOpen = false;
+        fakes.push(this);
+    }
+    configure() {
+        this.configureCount++;
+        if (this.configureThrows) {
+            throw this.configureThrows;
+        }
+        this.state = 'configured';
+    }
+    decode() {
+        this.decodeCount++;
+        if (this.decodeThrows) {
+            throw this.decodeThrows;
+        }
+    }
+    close() {
+        this.closeCount++;
+        this.state = 'closed';
+    }
+    flush() {
+        this.flushCount++;
+        if (this.flushThrowsSync) {
+            throw this.flushThrowsSync;
+        }
+        const d = {};
+        d.promise = new Promise(function(resolve, reject) {
+            d.resolve = resolve;
+            d.reject = reject;
+        });
+        this._pendingFlush = d;
+        return d.promise;
+    }
+
+    // Helpers the tests call to drive the decoder.
+    fireOutput(audioData) {
+        this._output(audioData);
+    }
+    fireError(err) {
+        this._error(err);
+        if (!this.errorLeavesStateOpen) {
+            this.state = 'closed';
+        }
+    }
+}
+
+function installFakes() {
+    fakes = [];
+    originalAudioDecoder = window.AudioDecoder;
+    originalEncodedAudioChunk = window.EncodedAudioChunk;
+    window.AudioDecoder = FakeAudioDecoder;
+    window.EncodedAudioChunk = FakeEncodedAudioChunk;
+}
+
+function restoreFakes() {
+    window.AudioDecoder = originalAudioDecoder;
+    window.EncodedAudioChunk = originalEncodedAudioChunk;
+}
+
+// Build a FakeAudioData prefilled with the values of `samples` on
+// every plane. Convenience for the simple "1 channel, ramp" tests.
+function makeFakeAudioData(samples, opts) {
+    opts = opts || {};
+    const channels = opts.channels || 1;
+    const rate = opts.rate || 48000;
+    return new FakeAudioData({
+        frames: samples.length,
+        channels: channels,
+        rate: rate,
+        fillPlanes: function(planeIndex, dst) {
+            for (let i = 0; i < samples.length; i++) {
+                dst[i] = samples[i];
+            }
+        }
+    });
+}
+
+describe('WebCodecsOpus lifecycle --', function() {
+    beforeEach(installFakes);
+    afterEach(restoreFakes);
+
+    describe('construction', function() {
+        it('creates and configures an AudioDecoder', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            equal(fakes.length, 1, 'one decoder instance was constructed');
+            equal(fakes[0].configureCount, 1);
+            equal(fakes[0].state, 'configured');
+            ok(dec.decoder === fakes[0]);
+        });
+
+        it('reports the requested output sample rate', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 24000});
+            equal(dec.getSampleRate(), 24000);
+        });
+
+        it('defaults to 48000 when no sampleRate is provided', function() {
+            const dec = new WebCodecsOpus(1, {});
+            equal(dec.getSampleRate(), 48000);
+        });
+
+        it('survives a configure() that throws synchronously', function() {
+            // Simulates "browser refuses our config" (e.g. a future
+            // Chrome that drops Opus support, or a misconfigured
+            // numberOfChannels). The constructor must not propagate;
+            // it should null the decoder and leave the instance in a
+            // safe no-op state.
+            const realConfigure = FakeAudioDecoder.prototype.configure;
+            FakeAudioDecoder.prototype.configure = function() {
+                throw new Error('not supported');
+            };
+            try {
+                const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+                equal(dec.decoder, null);
+                // decode() on a null decoder is a no-op (no throw).
+                dec.decode(new Uint8Array([1, 2, 3]));
+                dec.destroy();
+            } finally {
+                FakeAudioDecoder.prototype.configure = realConfigure;
+            }
+        });
+    });
+
+    describe('decode()', function() {
+        it('forwards an EncodedAudioChunk into the underlying decoder', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            dec.decode(new Uint8Array([1, 2, 3, 4]));
+            equal(fakes[0].decodeCount, 1);
+        });
+
+        it('is a no-op once destroyed', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const fake = fakes[0];
+            dec.destroy();
+            const before = fake.decodeCount;
+            dec.decode(new Uint8Array([1, 2, 3]));
+            equal(fake.decodeCount, before, 'no decode after destroy');
+        });
+
+        it('is a no-op when the underlying decoder is in closed state', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            fakes[0].state = 'closed';
+            dec.decode(new Uint8Array([1, 2, 3]));
+            equal(fakes[0].decodeCount, 0);
+        });
+
+        it('drops empty packets without calling decode', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            dec.decode(new Uint8Array(0));
+            dec.decode(null);
+            dec.decode(undefined);
+            equal(fakes[0].decodeCount, 0);
+        });
+
+        it('treats a synchronous decode() throw as a decoder error and rebuilds', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000, handleCorruptedStream: true});
+            const errs = [];
+            dec.on('corrupted_stream', function(e) { errs.push(e); });
+            const first = fakes[0];
+            first.decodeThrows = new Error('synthetic decode failure');
+            dec.decode(new Uint8Array([1, 2, 3]));
+            equal(errs.length, 1, 'corrupted_stream dispatched');
+            equal(fakes.length, 2, 'rebuilt to a fresh decoder');
+            ok(dec.decoder === fakes[1]);
+        });
+    });
+
+    describe('onAudioData()', function() {
+        it('dispatches a Float32Array of PCM at the source rate when src==dst', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const received = [];
+            dec.on('data', function(buf) { received.push(buf); });
+
+            fakes[0].fireOutput(makeFakeAudioData([0.1, 0.2, 0.3, 0.4]));
+
+            equal(received.length, 1);
+            ok(received[0] instanceof Float32Array);
+            deepEqual(Array.from(received[0]), [0.1, 0.2, 0.3, 0.4].map(function(v) {
+                // Float32Array round-trip is lossy for these values; accept the
+                // round-tripped form rather than the literal.
+                return Math.fround(v);
+            }));
+        });
+
+        it('decimates from 48k to 24k via block average', function() {
+            // Verifies the resample path actually wires through to
+            // decimateInterleave (the math itself is unit-tested
+            // separately).
+            const dec = new WebCodecsOpus(1, {sampleRate: 24000});
+            const received = [];
+            dec.on('data', function(buf) { received.push(buf); });
+
+            fakes[0].fireOutput(makeFakeAudioData([0, 1, 2, 3], {rate: 48000}));
+
+            equal(received.length, 1);
+            deepEqual(Array.from(received[0]), [0.5, 2.5]);
+        });
+
+        it('closes the AudioData even when listeners throw', function() {
+            // Critical for memory: AudioData wraps a native buffer
+            // that's only released on close(). Skipping close() on a
+            // listener exception would leak one buffer per output
+            // callback for the rest of the stream.
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            dec.on('data', function() { throw new Error('listener bug'); });
+            const data = makeFakeAudioData([0.1, 0.2]);
+            fakes[0].fireOutput(data);
+            equal(data.closeCount, 1);
+        });
+
+        it('listener throw does NOT trigger a decoder rebuild', function() {
+            // Without safeDispatch this would burn through the
+            // rebuild budget on a downstream consumer bug. With
+            // safeDispatch, the throw is swallowed and the decoder
+            // stays alive.
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            dec.on('data', function() { throw new Error('listener bug'); });
+            fakes[0].fireOutput(makeFakeAudioData([0.1, 0.2]));
+            equal(fakes.length, 1, 'no rebuild');
+        });
+
+        it('skips dispatch when the decoder produced zero frames', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const received = [];
+            dec.on('data', function(buf) { received.push(buf); });
+
+            fakes[0].fireOutput(new FakeAudioData({
+                frames: 0, channels: 1, rate: 48000,
+                fillPlanes: function() {}
+            }));
+
+            equal(received.length, 0);
+        });
+
+        it('resets rebuild budget on a successful output', function() {
+            // If a stream produces a single bad packet early on, we
+            // should burn one rebuild attempt and then NOT keep that
+            // attempt counted against later in the stream.
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000, handleCorruptedStream: true});
+            fakes[0].fireError(new Error('bad packet')); // burns 1
+            equal(dec.rebuildAttempts, 1);
+            const second = fakes[1];
+            second.fireOutput(makeFakeAudioData([0.1])); // good packet
+            equal(dec.rebuildAttempts, 0, 'budget reset');
+        });
+    });
+
+    describe('onError()', function() {
+        it('dispatches corrupted_stream when handleCorruptedStream=true', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000, handleCorruptedStream: true});
+            const errs = [];
+            dec.on('corrupted_stream', function(e) { errs.push(e); });
+            fakes[0].fireError(new Error('boom'));
+            equal(errs.length, 1);
+            equal(errs[0].message, 'boom');
+        });
+
+        it('does NOT dispatch corrupted_stream when the option is unset', function() {
+            // Default behavior -- consumer didn't opt in to seeing
+            // bad-frame events.
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const errs = [];
+            dec.on('corrupted_stream', function(e) { errs.push(e); });
+            fakes[0].fireError(new Error('boom'));
+            equal(errs.length, 0);
+        });
+
+        it('rebuilds the underlying AudioDecoder on each error', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            fakes[0].fireError(new Error('first'));
+            equal(fakes.length, 2, 'one rebuild');
+            ok(dec.decoder === fakes[1]);
+            equal(fakes[1].state, 'configured');
+        });
+
+        it('keeps timestamps monotonic across rebuilds', function() {
+            // WebCodecs requires strictly increasing input timestamps
+            // even across decoder.configure() boundaries. Verify our
+            // counter doesn't reset on rebuild.
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const before = dec.nextTimestamp;
+            dec.decode(new Uint8Array([1])); // bumps to 60000
+            fakes[0].fireError(new Error('boom')); // rebuild
+            ok(dec.nextTimestamp > before);
+        });
+
+        it('continues rebuilding up to MAX_REBUILD_ATTEMPTS, then gives up', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000, handleCorruptedStream: true});
+            const errs = [];
+            dec.on('corrupted_stream', function(e) { errs.push(e); });
+
+            // Fire 5 errors -> 5 rebuilds. After each, fakes[i+1]
+            // is the freshly-built decoder.
+            for (let i = 0; i < 5; i++) {
+                fakes[fakes.length - 1].fireError(new Error('e' + i));
+            }
+            equal(fakes.length, 6, '5 rebuilds (6 total decoders)');
+            ok(dec.decoder === fakes[5]);
+
+            // 6th error: budget exhausted. No new decoder.
+            fakes[5].fireError(new Error('e5'));
+            equal(fakes.length, 6, 'no rebuild after budget exhausted');
+            equal(dec.decoder, null);
+        });
+
+        it('dispatches a terminal corrupted_stream when budget exhausted', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000, handleCorruptedStream: true});
+            const errs = [];
+            dec.on('corrupted_stream', function(e) { errs.push(e); });
+
+            for (let i = 0; i < 6; i++) {
+                fakes[fakes.length - 1].fireError(new Error('e' + i));
+            }
+            // 6 raw errors + 1 terminal "budget exhausted" = 7
+            equal(errs.length, 7);
+            equal(errs[6].message, 'WebCodecs decoder rebuild budget exhausted');
+        });
+
+        it('explicitly closes the budget-exhausted decoder when the runtime didn\'t auto-close it', function() {
+            // The bug-review fix: even if a buggy/non-spec
+            // implementation doesn't transition the decoder to
+            // 'closed' on error, we must close it ourselves so its
+            // native handle isn't leaked to GC. Simulated by setting
+            // errorLeavesStateOpen on the fakes.
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000, handleCorruptedStream: true});
+            // First make all subsequent fakes non-spec.
+            const origCtor = window.AudioDecoder;
+            window.AudioDecoder = function(opts) {
+                const f = new origCtor(opts);
+                f.errorLeavesStateOpen = true;
+                return f;
+            };
+            // Mark the already-created first decoder too.
+            fakes[0].errorLeavesStateOpen = true;
+
+            try {
+                for (let i = 0; i < 6; i++) {
+                    fakes[fakes.length - 1].fireError(new Error('e' + i));
+                }
+                // Last decoder (fakes[5]) is the budget-exhausted one.
+                // closeDecoder() must have called close() on it
+                // because the fake never auto-transitioned to 'closed'.
+                equal(fakes[5].closeCount, 1, 'last decoder explicitly closed');
+            } finally {
+                window.AudioDecoder = origCtor;
+            }
+        });
+
+        it('skips the rebuild path when fired during destroy()', function() {
+            // The flush window can produce error callbacks for
+            // packets that were already in flight. We dispatch the
+            // event so the consumer sees it, but must not rebuild
+            // (we're tearing down).
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000, handleCorruptedStream: true});
+            const errs = [];
+            dec.on('corrupted_stream', function(e) { errs.push(e); });
+
+            const fakeBeforeDestroy = fakes[0];
+            dec.destroy();
+            const fakesBefore = fakes.length;
+            fakeBeforeDestroy.fireError(new Error('late'));
+            equal(fakes.length, fakesBefore, 'no rebuild during destroy');
+        });
+
+        it('listener throw on corrupted_stream does NOT skip the rebuild', function() {
+            // Without safeDispatch, a throwing listener would unwind
+            // out of onError before reaching the rebuild logic,
+            // leaving the stream silently dead.
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000, handleCorruptedStream: true});
+            dec.on('corrupted_stream', function() { throw new Error('listener bug'); });
+            fakes[0].fireError(new Error('boom'));
+            equal(fakes.length, 2, 'rebuild still happened');
+        });
+    });
+
+    describe('destroy()', function() {
+        it('is idempotent', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            dec.destroy();
+            // Second call must not call flush() again.
+            const flushBefore = fakes[0].flushCount;
+            dec.destroy();
+            equal(fakes[0].flushCount, flushBefore);
+        });
+
+        it('clears listeners synchronously when there is no decoder to flush', function() {
+            // Path: the constructor's buildDecoder() failed and
+            // returned null. destroy() should clear listeners
+            // immediately without trying to flush.
+            const realConfigure = FakeAudioDecoder.prototype.configure;
+            FakeAudioDecoder.prototype.configure = function() {
+                throw new Error('not supported');
+            };
+            try {
+                const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+                let fired = 0;
+                dec.on('data', function() { fired++; });
+                dec.destroy();
+                deepEqual(dec.listener, {}, 'listeners cleared');
+            } finally {
+                FakeAudioDecoder.prototype.configure = realConfigure;
+            }
+        });
+
+        it('flushes before close so tail PCM still reaches listeners', function(done) {
+            // The whole reason destroy() became async. Tail packets
+            // delivered between destroy() and the flush settling must
+            // still dispatch to consumers.
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const received = [];
+            dec.on('data', function(buf) { received.push(buf); });
+
+            const fake = fakes[0];
+            dec.destroy();
+
+            // Decoder isn't closed yet, listeners still alive.
+            equal(fake.closeCount, 0);
+            fake.fireOutput(makeFakeAudioData([0.1, 0.2]));
+            equal(received.length, 1, 'tail PCM dispatched');
+
+            // Now resolve the flush.
+            fake._pendingFlush.resolve();
+            // Wait a microtask for the .then handler to run.
+            Promise.resolve().then(function() {
+                equal(fake.closeCount, 1, 'closed after flush');
+                deepEqual(dec.listener, {}, 'listeners cleared');
+                done();
+            }).catch(done);
+        });
+
+        it('falls through to close() if flush() throws synchronously', function() {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const fake = fakes[0];
+            fake.flushThrowsSync = new Error('flush sync throw');
+            dec.destroy();
+            equal(fake.closeCount, 1);
+            deepEqual(dec.listener, {});
+        });
+
+        it('falls through to close() if flush() promise rejects', function(done) {
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const fake = fakes[0];
+            dec.destroy();
+            fake._pendingFlush.reject(new Error('flush rejected'));
+            Promise.resolve().then(function() {
+                // Microtask for .then handler.
+                return Promise.resolve();
+            }).then(function() {
+                equal(fake.closeCount, 1);
+                deepEqual(dec.listener, {});
+                done();
+            }).catch(done);
+        });
+
+        it('finalizes on timeout if flush() never settles', function(done) {
+            // The backstop. A real-world frozen flush would otherwise
+            // retain `dec` and the listener list forever. Wait
+            // FLUSH_TIMEOUT_MS + a small buffer for the timer to fire.
+            this.timeout(FLUSH_TIMEOUT_MS + 1500);
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const fake = fakes[0];
+            dec.destroy();
+            equal(fake.closeCount, 0, 'not yet closed');
+
+            setTimeout(function() {
+                try {
+                    equal(fake.closeCount, 1, 'closed after timeout');
+                    deepEqual(dec.listener, {}, 'listeners cleared');
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }, FLUSH_TIMEOUT_MS + 200);
+        });
+
+        it('does not double-close when flush settles after timeout fired', function(done) {
+            // The `finalized` guard. Both timeout and flush-resolve
+            // call finalize; only the first should take effect.
+            this.timeout(FLUSH_TIMEOUT_MS + 1500);
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const fake = fakes[0];
+            dec.destroy();
+
+            setTimeout(function() {
+                // Timeout has fired by now -> closeCount === 1.
+                // Resolving the deferred should NOT trigger a second
+                // close.
+                fake._pendingFlush.resolve();
+                Promise.resolve().then(function() {
+                    try {
+                        equal(fake.closeCount, 1, 'still only one close');
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                });
+            }, FLUSH_TIMEOUT_MS + 200);
+        });
+
+        it('does not fire timeout if flush resolves first', function(done) {
+            // The other half of the `finalized` guard: timeout
+            // shouldn't double-finalize after a fast flush. Hard to
+            // observe directly; we resolve the flush and then wait
+            // past the timeout to make sure closeCount is still 1.
+            this.timeout(FLUSH_TIMEOUT_MS + 1500);
+            const dec = new WebCodecsOpus(1, {sampleRate: 48000});
+            const fake = fakes[0];
+            dec.destroy();
+            fake._pendingFlush.resolve();
+
+            // Wait past FLUSH_TIMEOUT_MS to see if a stray timeout
+            // somehow fires a second close.
+            setTimeout(function() {
+                try {
+                    equal(fake.closeCount, 1, 'no double-close from late timeout');
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }, FLUSH_TIMEOUT_MS + 200);
+        });
+    });
+});

--- a/test/webcodecs-opus-resample.js
+++ b/test/webcodecs-opus-resample.js
@@ -1,0 +1,221 @@
+import {equal, deepEqual, ok, strictEqual} from 'assert';
+import {
+    toUint8Array,
+    interleave,
+    decimateInterleave,
+    linearResampleInterleave
+} from '../src/utils/webcodecs-opus.js';
+
+// These tests cover the pure helpers behind the WebCodecs path. Most
+// were tier-1 in the bug-review write-up: easy to test, no browser
+// features required, and the place where the most subtle behavior
+// lives (the resampling math is what made the first cut of the
+// decoder play back at half speed and an octave low).
+
+function f32(values) {
+    return Float32Array.from(values);
+}
+
+// Compare two Float32Arrays sample-by-sample within a tolerance. We
+// don't use `deepEqual` because it would require bit-exact equality
+// even for arithmetic that involves division.
+function approx(actual, expected, eps) {
+    eps = eps == null ? 1e-6 : eps;
+    equal(actual.length, expected.length, 'length mismatch');
+    for (let i = 0; i < actual.length; i++) {
+        const diff = Math.abs(actual[i] - expected[i]);
+        ok(diff <= eps,
+            'sample ' + i + ': expected ' + expected[i] +
+            ', got ' + actual[i] + ' (diff ' + diff + ' > eps ' + eps + ')');
+    }
+}
+
+describe('toUint8Array --', function() {
+    it('returns null for null/undefined', function() {
+        equal(toUint8Array(null), null);
+        equal(toUint8Array(undefined), null);
+    });
+
+    it('returns the same instance when given a Uint8Array', function() {
+        const buf = new Uint8Array([1, 2, 3]);
+        // Identity is intentional: avoids an unnecessary copy on the
+        // hot path. Callers that care must clone themselves.
+        strictEqual(toUint8Array(buf), buf);
+    });
+
+    it('wraps a raw ArrayBuffer in a Uint8Array view', function() {
+        const ab = new ArrayBuffer(4);
+        new Uint8Array(ab).set([10, 20, 30, 40]);
+        const out = toUint8Array(ab);
+        ok(out instanceof Uint8Array);
+        deepEqual(Array.from(out), [10, 20, 30, 40]);
+    });
+
+    it('wraps non-Uint8 typed arrays sharing the underlying buffer', function() {
+        // Critical: must respect byteOffset and byteLength so a
+        // sub-view of a larger ArrayBuffer doesn't get re-interpreted
+        // from offset 0 (which would silently send the wrong bytes
+        // into the decoder).
+        const big = new Uint8Array([0xAA, 0xBB, 1, 2, 3, 4, 0xCC]);
+        const view = new Uint8Array(big.buffer, 2, 4); // [1,2,3,4]
+        const i16 = new Int16Array(view.buffer, view.byteOffset, 2);
+        const out = toUint8Array(i16);
+        ok(out instanceof Uint8Array);
+        equal(out.byteOffset, 2);
+        equal(out.byteLength, 4);
+        deepEqual(Array.from(out), [1, 2, 3, 4]);
+    });
+
+    it('returns null for unsupported types', function() {
+        equal(toUint8Array('string'), null);
+        equal(toUint8Array(42), null);
+        equal(toUint8Array({}), null);
+        equal(toUint8Array([1, 2, 3]), null);
+    });
+});
+
+describe('interleave --', function() {
+    it('returns the single plane unchanged for mono', function() {
+        // Identity for mono is an explicit perf optimization; not just
+        // an incidental property. Locking it in so it doesn't silently
+        // regress to "always allocate and copy".
+        const plane = f32([1, 2, 3, 4]);
+        strictEqual(interleave([plane], 4, 1), plane);
+    });
+
+    it('interleaves stereo as [L0,R0,L1,R1,...]', function() {
+        const left = f32([1, 2, 3]);
+        const right = f32([10, 20, 30]);
+        const out = interleave([left, right], 3, 2);
+        deepEqual(Array.from(out), [1, 10, 2, 20, 3, 30]);
+    });
+
+    it('handles empty input', function() {
+        const out = interleave([f32([]), f32([])], 0, 2);
+        equal(out.length, 0);
+    });
+});
+
+describe('decimateInterleave --', function() {
+    it('decim=1 is identity (delegates to interleave)', function() {
+        const plane = f32([1, 2, 3]);
+        strictEqual(decimateInterleave([plane], 3, 1, 1), plane);
+    });
+
+    it('mono decim=2 averages adjacent pairs', function() {
+        // 48k -> 24k path. The most common production case for the
+        // SDK (narrowband/mediumband Opus streams).
+        const plane = f32([1, 2, 3, 4, 5, 6]);
+        const out = decimateInterleave([plane], 6, 1, 2);
+        approx(out, f32([1.5, 3.5, 5.5]));
+    });
+
+    it('drops trailing samples that don\'t fill a full block', function() {
+        // Documents the explicit floor() in the implementation.
+        // 5 samples / 2 = 2 output frames, last sample discarded.
+        const plane = f32([1, 2, 3, 4, 5]);
+        const out = decimateInterleave([plane], 5, 1, 2);
+        approx(out, f32([1.5, 3.5]));
+    });
+
+    it('mono decim=6 averages 6-sample blocks (48k -> 8k)', function() {
+        // Sanity check the largest production decimation factor.
+        const plane = f32([1, 1, 1, 1, 1, 1, 7, 7, 7, 7, 7, 7]);
+        const out = decimateInterleave([plane], 12, 1, 6);
+        approx(out, f32([1, 7]));
+    });
+
+    it('stereo decim=2 decimates each channel independently', function() {
+        const left = f32([1, 2, 3, 4]);
+        const right = f32([10, 20, 30, 40]);
+        const out = decimateInterleave([left, right], 4, 2, 2);
+        // [L0avg, R0avg, L1avg, R1avg] = [1.5, 15, 3.5, 35]
+        approx(out, f32([1.5, 15, 3.5, 35]));
+    });
+
+    it('preserves DC: constant input produces the same constant output', function() {
+        // Critical property of any anti-alias filter that's a unity-DC
+        // FIR: the boxcar's coefficients are 1/N each, so for any
+        // constant input the output equals that same constant. If a
+        // future change accidentally drops the 1/N normalization (or
+        // rescales it), this test catches it instantly.
+        const N = 12;
+        const plane = new Float32Array(N);
+        plane.fill(0.42);
+        const out = decimateInterleave([plane], N, 1, 4);
+        approx(out, f32([0.42, 0.42, 0.42]));
+    });
+
+    it('attenuates the source-Nyquist sinusoid (anti-aliasing sanity)', function() {
+        // The boxcar's first null is at srcRate/N. For decim=2 that's
+        // exactly the source Nyquist, which means a +/-1 alternating
+        // signal (the worst-case alias source) collapses to ~0. Test
+        // that we get strong attenuation, not the +/-1 you'd see from
+        // naive subsampling.
+        const N = 16;
+        const plane = new Float32Array(N);
+        for (let i = 0; i < N; i++) {
+            plane[i] = (i % 2 === 0) ? 1 : -1;
+        }
+        const out = decimateInterleave([plane], N, 1, 2);
+        // Block average of [1,-1] = 0.
+        for (let i = 0; i < out.length; i++) {
+            ok(Math.abs(out[i]) < 1e-9,
+                'expected near-zero at index ' + i + ', got ' + out[i]);
+        }
+    });
+});
+
+describe('linearResampleInterleave --', function() {
+    it('mono identity-rate resample reproduces the input', function() {
+        // Linear interp at i=0 picks i0=0, frac=0 -> exactly src[0].
+        // At other integer src positions, frac=0 again. So sampling
+        // at the same rate is a no-op modulo float math.
+        const plane = f32([1, 2, 3, 4]);
+        const out = linearResampleInterleave([plane], 4, 1, 48000, 48000);
+        approx(out, plane);
+    });
+
+    it('mono 2:1 down via linear interp gives mid-point of pairs', function() {
+        // ratio=2, so output sample i is src[2i]; not interpolated.
+        // (linear interp degenerates to nearest when frac is exactly
+        // 0.) That's fine for non-integer ratios where this branch
+        // actually runs; this case just documents the math.
+        const plane = f32([0, 10, 20, 30, 40, 50]);
+        const out = linearResampleInterleave([plane], 6, 1, 48000, 24000);
+        approx(out, f32([0, 20, 40]));
+    });
+
+    it('mono 3:2 fractional resample interpolates between samples', function() {
+        // ratio = 1.5. Output positions in src: 0, 1.5, 3.0, ...
+        //   i=0: src[0]                              = 0
+        //   i=1: src[1] + 0.5 * (src[2] - src[1])    = 10 + 5  = 15
+        //   i=2: src[3]                              = 30
+        //   i=3: src[4] + 0.5 * (src[5] - src[4])    = 40 + 5  = 45
+        const plane = f32([0, 10, 20, 30, 40, 50]);
+        // outFrames = floor(6 * 2/3) = 4
+        const out = linearResampleInterleave([plane], 6, 1, 48000, 32000);
+        approx(out, f32([0, 15, 30, 45]));
+    });
+
+    it('clamps the upper interpolation index to the last frame', function() {
+        // The implementation uses Math.min(i0+1, numFrames-1). Without
+        // that clamp, the very last output sample reads past the end
+        // of the source plane and grabs whatever sentinel zero the
+        // typed-array allocator left there. This test forces the
+        // clamp to matter by making the last output sample land
+        // exactly on the last source sample.
+        const plane = f32([1, 2, 3, 4]);
+        // outFrames = floor(4 * 4/4) = 4. ratio = 1.
+        const out = linearResampleInterleave([plane], 4, 1, 4, 4);
+        approx(out, plane);
+    });
+
+    it('stereo resamples each channel independently', function() {
+        const left = f32([0, 10, 20, 30, 40, 50]);
+        const right = f32([0, 100, 200, 300, 400, 500]);
+        const out = linearResampleInterleave([left, right], 6, 2, 48000, 32000);
+        // Same positions as the mono 3:2 case, x10 on the right.
+        approx(out, f32([0, 0, 15, 150, 30, 300, 45, 450]));
+    });
+});


### PR DESCRIPTION
[DESKTOP-569](https://zelloptt.atlassian.net/browse/DESKTOP-569)

## Summary

Add an opt-in `useNative: true` decoding path in `OpusToPCM` that decodes Opus through the browser's `WebCodecs` `AudioDecoder` instead of the Emscripten-compiled libopus Web Worker. Default behavior is unchanged for every existing consumer; only callers that explicitly pass `useNative: true` get the new path.

The motivation is Dispatch Hub: the `OpusWorker` path costs us a ~918 KB worker bundle, a fresh V8 isolate, and PartitionAlloc pages that don't reliably return to the OS per concurrent message. WebCodecs runs in the browser's media pipeline (typically off-thread, often platform-backed) and skips all of that.

## What's in here

- `WebCodecsOpus` class implementing the same `decode` / `destroy` / `getSampleRate` / `'data'` / `'corrupted_stream'` contract as `OpusWorker` and `Ogg`, so it slots into `OpusToPCM` without touching the player.
- Resampling from the WebCodecs-fixed 48 kHz output to whatever sample rate the SDK negotiates (commonly 24 kHz). Without this, playback comes out an octave low and at half speed.
- Block-average decimation (boxcar FIR) for integer-factor downsamples so wideband content squeezed into 16/12/8 kHz targets doesn't alias.
- `flush()`-then-`close()` on `destroy()` so tail PCM still reaches the player; previous synchronous `close()` was dropping the last few packets and leaving messages stuck.
- Decode-error recovery: rebuild the underlying `AudioDecoder` up to a small budget on errors (mirrors libopus's tolerance for malformed frames). Once the budget is exhausted we explicitly `close()` the decoder and surface a terminal `'corrupted_stream'` event instead of failing silently.
- Listener-throw isolation via `safeDispatch`, plus a `FLUSH_TIMEOUT_MS` backstop so a stuck flush can't pin the decoder instance forever.
- 65 tests across three tiers (up from 7):
  - Pure-math: `interleave` / `decimateInterleave` / `linearResampleInterleave` / `toUint8Array`.
  - Lifecycle: state machine driven by a hand-rolled fake `AudioDecoder`; covers rebuild logic, budget exhaustion, the `destroy()` timeout, listener isolation.
  - Integration: real `AudioEncoder` to `WebCodecsOpus` roundtrip in Chrome at both 48 kHz and 24 kHz output rates.

## Performance

Side-by-side bench of `WebCodecsOpus` vs `OpusWorker` against a shared corpus of 150 x 20 ms 1 kHz Opus packets at 48 kHz. Numbers below are the median of three runs in Chrome 147 on an Apple Silicon MacBook. Bench harness was run locally and is not part of this PR.

### Realtime (one packet per 20 ms, what production looks like)

| Metric | WebCodecsOpus | OpusWorker | Worker / WC |
|---|---:|---:|---:|
| TTFP (ms) | ~5 | ~42 | ~8x |
| Mean per-packet latency (ms) | ~0.4 | ~1.6 | ~4x |
| p50 latency (ms) | ~0.2 | ~0.5 | ~2-3x |
| p95 latency (ms) | ~2-4 | ~5-6 | ~1.4-3x |
| Heap delta, main thread (KB) | ~663 | ~669 | ~1.0x |

### Burst (fire all packets ASAP, peak throughput / queue-fill)

| Metric | WebCodecsOpus | OpusWorker | Worker / WC |
|---|---:|---:|---:|
| TTFP (ms) | ~0.8 | ~44 | ~50x |
| Wall total (ms) | ~260 | ~365 | ~1.4x |
| Mean latency (ms) | ~3.3 | ~94 | ~28x |
| p50 latency (ms) | ~3.3 | ~98 | ~30x |
| p95 latency (ms) | ~5.5 | ~108 | ~20x |
| Heap delta, main thread (KB) | ~675 | ~1570 | ~2.3x |

### Reading the numbers

- **TTFP is the headline win.** WebCodecs starts emitting PCM within ~1-5 ms; the worker pays a ~40 ms libopus / Emscripten / postMessage round-trip startup. For a PTT app this is "press transmit -> first audible audio" latency.
- **Steady state is also a real win.** Once warm, WebCodecs delivers PCM in ~0.4 ms vs ~1.6 ms for the worker. Both are fast enough on their own; WebCodecs has more headroom under jitter.
- **Burst latency for the worker is misleading on its own.** Queueing 150 packets via `postMessage` at once stacks ~95 ms of pipeline lag; that's not "the worker takes 95 ms to decode a packet". Realtime is the honest steady-state figure.
- **Throughput.** Burst wall total of 260 vs 365 ms (~1.4x) is real CPU throughput — WebCodecs decodes the 3 s corpus in ~12x realtime, the worker in ~8x realtime. Plenty of headroom either way for a single stream.
- **Memory caveats.** Heap delta is main-thread only. The worker isolate's libopus heap (~1-2 MB per `OpusWorker`) and any V8/PartitionAlloc pages it pins are NOT counted here — that's the original DESKTOP-569 RSS-growth tail. The 918 KB worker source `Blob` is cached at module scope and amortizes to once per page life. WebCodecs needs none of that.

## Risk

- Default path (`useNative` unset / false) is byte-identical to today; `OpusWorker` is untouched.
- Feature detection on `typeof AudioDecoder !== 'undefined'`; falls back to `OpusWorker` when `fallback: true` (default). Firefox / non-Chromium hosts behave exactly as before.
- One stylistic regression: `catch (_) {}` instead of `catch {}`. Required by the Karma test runner's old `babel-preset-es2015`, which can't parse ES2018 optional catch binding. Easy to revert once the test toolchain is bumped.

## Out of scope

- Wiring `npm test` into CI (this repo currently has none). Worth a follow-up so the new test suite actually gates future PRs.
- Flipping `useNative: true` on in Dispatch Hub. That's a `zello-desktop` change after this lands and a new SDK is published.


[DESKTOP-569]: https://zelloptt.atlassian.net/browse/DESKTOP-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
